### PR TITLE
Make stack frame keys (u/d) match order in stack frame list

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -22,8 +22,8 @@ Keys:
     t - run to cursor
     e - show traceback [post-mortem or in exception state]
 
-    u - move up one stack frame
-    d - move down one stack frame
+    u - move down one stack frame
+    d - move up one stack frame
 
     ! - invoke python shell in current environment
     o - show console/output screen
@@ -474,8 +474,8 @@ class DebuggerUI(FrameVarInfoKeeper):
         def move_stack_down(w, size, key):
             self.debugger.move_down_frame()
 
-        self.stack_list.listen("u", move_stack_up)
-        self.stack_list.listen("d", move_stack_down)
+        self.stack_list.listen("d", move_stack_up)
+        self.stack_list.listen("u", move_stack_down)
         self.source_sigwrap.listen("u", move_stack_up)
         self.source_sigwrap.listen("d", move_stack_down)
 


### PR DESCRIPTION
You don't have to accept this, but it seemed to me that the keys for the stack frame were backward, given that the top most level of the stack is at the top of the stack list.

Maybe a better fix would be to make it bottom to top in the list again.
