### PR TITLE
Update custom stringifier example with a method to use sub-second timeout

### DIFF
--- a/example-stringifier.py
+++ b/example-stringifier.py
@@ -53,7 +53,8 @@ def run_with_timeout(code, time, globals=None):
     """
     Evaluate ``code``, timing out after ``time`` seconds.
 
-    ``time`` must be an integer. The return value is whatever ``code`` returns.
+    In Python 2.5 and lower, ``time`` is rounded up to the nearest integer.
+    The return value is whatever ``code`` returns.
     """
     # Set the signal handler and a ``time``-second alarm
     signal.signal(signal.SIGALRM, lambda s, f: timeout(s, f, time))


### PR DESCRIPTION
The trick is to use `signal.setitimer` instead of `signal.alarm` (see http://docs.python.org/library/signal.html#signal.setitimer), which unfortunately only exists in Python 2.6+.
