### PR TITLE
encoding detection

### DIFF
--- a/pudb/lowlevel.py
+++ b/pudb/lowlevel.py
@@ -78,7 +78,7 @@ def lookup_module(filename):
 # stolen from Python 3.1's tokenize.py, by Ka-Ping Yee
 
 import re
-cookie_re = re.compile("coding[:=]\s*([-\w.]+)")
+cookie_re = re.compile("^\s*#.*coding[:=]\s*([-\w.]+)")
 from codecs import lookup, BOM_UTF8
 
 def detect_encoding(readline):

--- a/test/test-encoding.py
+++ b/test/test-encoding.py
@@ -1,0 +1,5 @@
+def f(encoding=None):
+	print 'ENCODING:', encoding
+
+from pudb import runcall
+runcall(f)


### PR DESCRIPTION
pudb was crashing with 'unknown encoding: None' because of a function which had an optional argument of `encoding=None`.

As specified in the pep, the encoding directive must be a comment.
I've altered the regex accordingly.

http://www.python.org/dev/peps/pep-0263/
