### PR TITLE
Fixed a writer the duplicate breakpoints when working with Django

### DIFF
--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -400,8 +400,9 @@ def save_breakpoints(bp_list):
     from os.path import join
     bp_histfile = join(get_save_config_path(), "saved-breakpoints")
     histfile = open(bp_histfile, 'w')
+    bp_list = set([(bp.file, bp.line) for bp in bp_list])
     for bp in bp_list:
-        histfile.write("b %s:%d\n"%(bp.file, bp.line))
+        histfile.write("b %s:%d\n" % (bp[0], bp[1]))
     histfile.close()
 
 # }}}


### PR DESCRIPTION
When we work with the Django runserver, then pressing the Continue or Next is a duplication breakpoints, my friends came up to 30,000 breakpoints, the application freezes and we do:
$ echo -n > ~/.config/pudb/saved-breakpoints

Now I have fixed this place, I hope it will help many!
