### PR TITLE
Start fixing issue #42 and hopefully #31.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,8 +48,6 @@ Install PuDB using the command::
 
     easy_install pudb
 
-
-
 Getting Started
 ---------------
 
@@ -82,13 +80,25 @@ PuDB also has a `mailing list <http://lists.tiker.net/listinfo/pudb>`_ that
 you may use to submit patches and requests for help.  You can also send a pull
 request to the `GitHub repository <https://github.com/inducer/pudb>`_
 
+Attaching to Running Code
+-------------------------
+
+An alternative to using ``set_trace`` is to use::
+
+    from pudb import set_interrupt_handler; set_interrupt_handler()
+
+at the top of your code.  This will set ``SIGINT`` (i.e., ``Ctrl-c``) to
+run ``set_trace``, so that typing ``Ctrl-c`` while your code is running
+will break the code and start debugging.  See the docstring of
+``set_interrupt_handler`` for more information.
+
 Programming PuDB
 ----------------
 
 At the programming language level, PuDB displays the same interface
 as Python's built-in `pdb module <http://docs.python.org/library/pdb.html>`_.
-Just replace `pdb` with `pudb`.
-(One exception: `run` is called `runstatement`.)
+Just replace ``pdb`` with ``pudb``.
+(One exception: ``run`` is called ``runstatement``.)
 
 License and Dependencies
 ------------------------

--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -128,7 +128,19 @@ def _interrupt_handler(signum, frame):
 def set_interrupt_handler(interrupt_signal=DEFAULT_SIGNAL):
     """
     Set up an interrupt handler, to activate PuDB when Python receives the
-    signal `interrupt_signal`.  By default it is SIGINT (i.e., Control-C).
+    signal `interrupt_signal`.  By default it is SIGINT (i.e., Ctrl-c).
+
+    To use a different signal, pass it as the argument to this function, like
+    `set_interrupt_handler(signal.SIGALRM)`.  You can then break your code
+    with `kill -ALRM pid`, where `pid` is the process ID of the Python
+    process.  Note that PuDB will still use SIGINT once it is running to allow
+    breaking running code.  If that is an issue, you can change the default
+    signal by hooking `pudb.DEFAULT_SIGNAL`, like
+
+    >>> import pudb
+    >>> import signal
+    >>> pudb.DEFAULT_SIGNAL = signal.SIGALRM
+
     """
     import signal
     signal.signal(interrupt_signal, _interrupt_handler)

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -56,7 +56,7 @@ Keys:
     m - open module
 
     j/k - up/down
-    ctrl-u/d - page up/down
+    Ctrl-u/d - page up/down
     h/l - scroll left/right
     g/G - start/end
     L - show (file/line) location / go to line
@@ -69,6 +69,8 @@ Keys:
 
     f1/?/H - show this help screen
     q - quit
+
+    Ctrl-c - when in continue mode, break back to PuDB
 
 Side-bar related:
 


### PR DESCRIPTION
For now, I have fixed #42 (except it doesn't yet work with `set_trace()`).  To
fix #31, I need to figure out what the best signal to use is.

@inducer, can you please verify that I've put this in the best place in the
code? As far as I can tell, `set_trace()` follows a completely different code
path, so it will require a separate handler.  I tried to put it in the part of
the code that the comments said was for setup just before the debugger starts,
so it should hopefully minimize bizarre things happening if someone press
Control-C before the debugger actually starts up.
