### PR TITLE
Fixed distribute_setup usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 
-from distribute_setup import use_setuptools
-
-use_setuptools()
-
 from setuptools import setup
 from pudb import VERSION
 


### PR DESCRIPTION
Everyone who installs pudb with an installer is guaranteed to already have distribute.
