### PR TITLE
don't provoke undefined signal handling

### DIFF
--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -153,6 +153,18 @@ def set_interrupt_handler(interrupt_signal=DEFAULT_SIGNAL):
     Note, this may not work if you use threads or subprocesses.
     """
     import signal
+    old_handler = signal.getsignal(interrupt_signal)
+
+    if old_handler is not signal.default_int_handler and old_handler != signal.SIG_DFL:
+        # Since we don't currently have support for a non-default signal handlers,
+        # let's avoid undefined-behavior territory and just show a warning.
+        from warnings import warn
+        if old_handler is None:
+            # This is the documented meaning of getsignal()->None.
+            old_handler = 'not installed from python'
+        return warn("A non-default handler for signal %d is already installed (%s). Skipping pudb interrupt support." 
+                % (interrupt_signal, old_handler))
+
     try:
         signal.signal(interrupt_signal, _interrupt_handler)
     except ValueError:
@@ -193,3 +205,5 @@ def pm():
 
 if __name__ == "__main__":
     print("You now need to type 'python -m pudb.run'. Sorry.")
+
+# vim: foldmethod=marker:expandtab:softtabstop=4

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1665,4 +1665,4 @@ class DebuggerUI(FrameVarInfoKeeper):
 
     # }}}
 
-# vim: foldmethod=marker
+# vim: foldmethod=marker:expandtab:softtabstop=4


### PR DESCRIPTION
mod_wsgi installs a non-default signal handler for SIGINT.

The current behavior of pudb utterly clobbers this signal handler and causes undefined behavior (in practice, the process becomes impossible to kill with SIGINT).

Until pudb has better support for non-default signal handlers in the process-under-test, I've added this small amount of code to detect the situation, throw a warning, and continue without interrupt support.

The new warning looks like this under apache.

```
[Mon Jun 10 18:44:30 2013] [error] /home/buck/trees/theirs/pudb/pudb/__init__.py:166: UserWarning: A non-default handler for signal 2 is already installed (not installed from python). Skipping pudb interrupt support.
[Mon Jun 10 18:44:30 2013] [error]   % (interrupt_signal, old_handler))
```

Then the process continues to work as well as previous versions of pudb.

In terms of priority, this is driving everyone that has upgraded pudb completely nuts, and the only recourse is to downgrade.
