### PR TITLE
A way to un-breakpoint a set_trace() line

### DIFF
--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -148,7 +148,7 @@ def set_trace():
 
 def _interrupt_handler(signum, frame):
     from pudb import _get_debugger
-    _get_debugger().set_trace(frame)
+    _get_debugger().set_trace(frame, as_breakpoint=False)
 
 
 def set_interrupt_handler(interrupt_signal=DEFAULT_SIGNAL):

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -157,7 +157,9 @@ class Debugger(bdb.Bdb):
 
         If frame is not specified, debugging starts from caller's frame.
 
-        This is exactly the same as Bdb.set_trace(), sans the self.reset() call.
+        Unlike Bdb.set_trace(), this does not call self.reset(), which causes
+        the debugger to enter bdb source code. This also implements treating
+        set_trace() calls as breakpoints in the PuDB UI.
         """
         if frame is None:
             frame = thisframe = sys._getframe().f_back
@@ -466,6 +468,8 @@ class FileSourceCodeProvider(SourceCodeProvider):
             return [SourceLine(self, self.file_name)]
 
         breakpoints = debugger_ui.debugger.get_file_breaks(self.file_name)
+        breakpoints += [i for f, i in debugger_ui.debugger.set_traces if f
+            == self.file_name and debugger_ui.debugger.set_traces[f, i]]
         try:
             from linecache import getlines
             lines = getlines(self.file_name)

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1050,6 +1050,7 @@ class DebuggerUI(FrameVarInfoKeeper):
                     file_lineno = (bp_source_identifier, lineno)
                     if file_lineno in self.debugger.set_traces:
                         self.debugger.set_traces[file_lineno] = not self.debugger.set_traces[file_lineno]
+                        sline.set_breakpoint(self.debugger.set_traces[file_lineno])
                         return
 
                     from pudb.lowlevel import get_breakpoint_invalid_reason

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -187,9 +187,12 @@ class Debugger(bdb.Bdb):
 
         thisframe_info = (self.canonic(thisframe.f_code.co_filename), thisframe.f_lineno)
         if thisframe_info not in self.set_traces or self.set_traces[thisframe_info]:
+            self.set_traces[thisframe_info] = True
+            if self.ui.source_code_provider is not None:
+                self.ui.set_source_code_provider(self.ui.source_code_provider, force_update=True)
+
             self.set_step()
             sys.settrace(self.trace_dispatch)
-            self.set_traces[thisframe_info] = True
         else:
             self.set_continue()
 

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -163,7 +163,7 @@ class Debugger(bdb.Bdb):
         for bpoint_descr in load_breakpoints():
             self.set_break(*bpoint_descr)
 
-    def set_trace(self, frame=None):
+    def set_trace(self, frame=None, as_breakpoint=True):
         """Start debugging from `frame`.
 
         If frame is not specified, debugging starts from caller's frame.
@@ -187,9 +187,10 @@ class Debugger(bdb.Bdb):
 
         thisframe_info = (self.canonic(thisframe.f_code.co_filename), thisframe.f_lineno)
         if thisframe_info not in self.set_traces or self.set_traces[thisframe_info]:
-            self.set_traces[thisframe_info] = True
-            if self.ui.source_code_provider is not None:
-                self.ui.set_source_code_provider(self.ui.source_code_provider, force_update=True)
+            if as_breakpoint:
+                self.set_traces[thisframe_info] = True
+                if self.ui.source_code_provider is not None:
+                    self.ui.set_source_code_provider(self.ui.source_code_provider, force_update=True)
 
             self.set_step()
             sys.settrace(self.trace_dispatch)

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -505,7 +505,7 @@ class FileSourceCodeProvider(SourceCodeProvider):
         if self.file_name == "<string>":
             return [SourceLine(self, self.file_name)]
 
-        breakpoints = debugger_ui.debugger.get_file_breaks(self.file_name)
+        breakpoints = debugger_ui.debugger.get_file_breaks(self.file_name)[:]
         breakpoints += [i for f, i in debugger_ui.debugger.set_traces if f
             == self.file_name and debugger_ui.debugger.set_traces[f, i]]
         try:


### PR DESCRIPTION
This sounds kind of odd, let me explain.  I usually enter the debugger with an explicit call to set_trace().  Often, once I've hit that line a few times, I no longer need to stop there, but I don't want to restart the process.

Just as I can manually turn a regular line into a breakpoint with the 'b' command, I would love a way to turn a set_trace() line back into a regular, non-breaking line.  The set_trace function would still be called of course, but could examine the calling line to see if it had been marked as non-breaking, and continue.