### PR TITLE
fix IPython deprecation warning in 1.0+

### DIFF
--- a/pudb/shell.py
+++ b/pudb/shell.py
@@ -113,9 +113,15 @@ def run_ipython_shell_v11(locals, globals, first_time):
     else:
         banner = ""
 
-    from IPython.frontend.terminal.interactiveshell import \
-            TerminalInteractiveShell
-    from IPython.frontend.terminal.ipapp import load_default_config
+    try:
+        # IPython 1.0 got rid of the frontend intermediary, and complains with
+        # a deprecated warning when you use it.
+        from IPython.terminal.interactiveshell import TerminalInteractiveShell
+        from IPython.terminal.ipapp import load_default_config
+    except ImportError:
+        from IPython.frontend.terminal.interactiveshell import \
+                TerminalInteractiveShell
+        from IPython.frontend.terminal.ipapp import load_default_config
     # XXX: in the future it could be useful to load a 'pudb' config for the
     # user (if it exists) that could contain the user's macros and other
     # niceities.


### PR DESCRIPTION
Hi Andreas and Aaron! hope this drive-by patch finds you in good health and in
good spirits.

Prior to this commit, users of IPython 1.0 and higher would be greeted with a
deprecation warning like this:

```
/home/pi/code/ipython/IPython/frontend.py:30: UserWarning: The
```

   top-level `frontend` package has been deprecated. All its
   subpackages have been moved to the top `IPython` level.

This commit addresses that for newer version of IPython, preserving the old
behavior if importing from the new location fails.
