### PR TITLE
Add pudb.b

### DIFF
--- a/pudb/b.py
+++ b/pudb/b.py
@@ -1,0 +1,19 @@
+import sys
+
+from pudb import _get_debugger, set_interrupt_handler
+
+def __myimport__(name, *args, **kwargs):
+    if name == 'pudb.b':
+        set_trace()
+    return __origimport__(name, *args, **kwargs)
+
+# Will only be run on first import
+__builtins__['__origimport__'] = __import__
+__builtins__['__import__'] = __myimport__
+
+def set_trace():
+    dbg = _get_debugger()
+    set_interrupt_handler()
+    dbg.set_trace(sys._getframe().f_back.f_back)
+
+set_trace()


### PR DESCRIPTION
This lets you just run

``` py
import pudb.b
```

to trigger a set_trace(). It works by monkey-patching
`__builtins__.__import__`. It does not yet work in Python 3.3, due to the new
import mechanism.

See #109.
