### PR TITLE
Allow filter on variables list

### DIFF
--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -3,6 +3,7 @@
 # {{{ constants and imports
 
 import urwid
+import re
 
 try:
     import numpy
@@ -456,7 +457,30 @@ class TopAndMainVariableWalker(ValueWalker):
 SEPARATOR = urwid.AttrMap(urwid.Text(""), "variable separator")
 
 
-def make_var_view(frame_var_info, locals, globals):
+def checkInnerFilter(f, var, regex):
+    if not regex:
+        pattern = r".*" + f.strip() + ".*"
+    else:
+        pattern = f.strip()
+
+    return re.search(pattern, var, re.I)
+
+
+def checkFilter(var, filter, regex):
+    isOnFilter = True
+    if (filter):
+        if re.search(r",", filter):
+            splitFilter = filter.split(",")
+            for f in splitFilter:
+                isOnFilter = checkInnerFilter(f, var, regex)
+                if isOnFilter:
+                    break
+        else:
+            isOnFilter = checkInnerFilter(filter, var, regex)
+
+    return isOnFilter
+
+def make_var_view(frame_var_info, locals, globals, filter, regex):
     vars = list(locals.keys())
     vars.sort(key=lambda n: n.lower())
 
@@ -478,7 +502,7 @@ def make_var_view(frame_var_info, locals, globals):
                 attr_prefix="return")
 
     for var in vars:
-        if not var[0] in "_.":
+        if not var[0] in "_." and checkFilter(var, filter, regex):
             tmv_walker.walk_value("", var, locals[var])
 
     result = tmv_walker.main_widget_list

--- a/try-the-debugger.sh
+++ b/try-the-debugger.sh
@@ -6,4 +6,4 @@ else
   PYINTERP="$1"
 fi
 
-$PYINTERP -m pudb.run debug_me.py
+$PYINTERP -m pudb debug_me.py


### PR DESCRIPTION
With non trivial script, variables list becomes a huge list, making it somewhat unmanageable. Sorting by most recent update (another open [issue](https://github.com/inducer/pudb/issues/107)) would do help but It would be cool to allow **"/"** key to start a filter on variables list

Here you are some quick thoughs:
- use \* as regex .*
- use , to search multiple patterns
- use . to search on second level variables (nested)

examples:
- first,last

Show variables **first** and **last**
- current\* 

Show variables like **currentLine**, **currentColumn**, **currentFile**...
- element.pos,.size

Show variable **pos** inside **variable** element, an every **size** variable inside whatever variable
