### PR TITLE
Redirect input, output and error at demand

### DIFF
--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -44,8 +44,8 @@ DEFAULT_SIGNAL = signal.SIGINT
 del signal
 
 
-def runscript(mainpyfile, args=None, pre_run="", steal_output=False):
-    dbg = _get_debugger(steal_output=steal_output)
+def runscript(mainpyfile, args=None, pre_run="", steal_output=False, input="/dev/stdin", output="/dev/stdout", error="/dev/stderr"):
+    dbg = _get_debugger(steal_output=steal_output, input=input, output=output, error=error)
 
     # Note on saving/restoring sys.argv: it's a good idea when sys.argv was
     # modified by the script being debugged. It's a bad idea when it was

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -144,7 +144,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 # {{{ debugger interface
 
 class Debugger(bdb.Bdb):
-    def __init__(self, steal_output=False):
+    def __init__(self, steal_output=False, input="/dev/stdin", output="/dev/stdout", error="/dev/stderr"):
         bdb.Bdb.__init__(self)
         self.ui = DebuggerUI(self)
         self.steal_output = steal_output
@@ -159,6 +159,10 @@ class Debugger(bdb.Bdb):
                 from cStringIO import StringIO
             self.stolen_output = sys.stderr = sys.stdout = StringIO()
             sys.stdin = StringIO("")  # avoid spurious hangs
+
+        sys.stdin = open(input, "r")
+        sys.stdout = open(output, 'w')
+        sys.stderr = open(error, 'w')
 
         from pudb.settings import load_breakpoints
         for bpoint_descr in load_breakpoints():

--- a/pudb/run.py
+++ b/pudb/run.py
@@ -5,6 +5,9 @@ def main():
     parser = OptionParser(
             usage="usage: %prog [options] SCRIPT-TO-RUN [SCRIPT-ARGUMENTS]")
 
+    parser.add_option("-i", "--input", help="file to get input", default="/dev/stdin", metavar="STDIN"),
+    parser.add_option("-o", "--output", help="file to flush output", default="/dev/stdout", metavar="STDOUT"),
+    parser.add_option("-e", "--error", help="file to flush errors", default="/dev/stderr", metavar="STDERR"),
     parser.add_option("-s", "--steal-output", action="store_true"),
     parser.add_option("--pre-run", metavar="COMMAND",
             help="Run command before each program run",
@@ -27,7 +30,7 @@ def main():
     from pudb import runscript
     runscript(mainpyfile,
             pre_run=options.pre_run,
-            steal_output=options.steal_output)
+            steal_output=options.steal_output, input=options.input, output=options.output)
 
 
 


### PR DESCRIPTION
I start this feature based on [this conversation](http://lists.tiker.net/pipermail/pudb/2013-May/000174.html). 

I need to debug a python [script which acts like a filter](https://github.com/albfan/filter-word-diff), so I'm interested on provide input and see output while debugging

I don't want to mess my code with std redirections when debugger can be told to do so

to use:

```
$ pudb -i /some/file -o /dev/pts/1 script.py
```
