### PR TITLE
Allow raw mode on rxvt terminals

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -394,7 +394,11 @@ want_curses_display = (
         or (
             CONFIG["display"] == "auto"
             and
-            not os.environ.get("TERM", "").startswith("xterm")))
+            not (
+                os.environ.get("TERM", "").startswith("xterm")
+                or
+                os.environ.get("TERM", "").startswith("rxvt")
+            )))
 
 from urwid.raw_display import Screen as RawScreen
 if want_curses_display:


### PR DESCRIPTION
My custom 256 color theme was broken since v2013.5, (more precisely commit afe202cdd09825be5e2ade9cc106845cbabde3a0), because I use rxvt instead of xterm.

This fixes it.