### PR TITLE
Added toggle sidebar feature

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -673,6 +673,8 @@ class DebuggerUI(FrameVarInfoKeeper):
             urwid.AttrMap(self.columns, "background"),
             header))
 
+        self._toggle_sidebar(CONFIG["sidebar_visible"])
+
         # }}}
 
         def change_rhs_box(name, index, direction, w, size, key):
@@ -1614,6 +1616,14 @@ class DebuggerUI(FrameVarInfoKeeper):
                 self.columns.column_types[1] = "weight", weight
                 self.columns._invalidate()
 
+        def toggle_sidebar(w, size, key):
+            from pudb.settings import save_config
+
+            CONFIG["sidebar_visible"] = not CONFIG["sidebar_visible"]
+            save_config(CONFIG)
+
+            self._toggle_sidebar(CONFIG["sidebar_visible"])
+
         self.rhs_col_sigwrap.listen("=", max_sidebar)
         self.rhs_col_sigwrap.listen("+", grow_sidebar)
         self.rhs_col_sigwrap.listen("_", min_sidebar)
@@ -1722,6 +1732,7 @@ class DebuggerUI(FrameVarInfoKeeper):
         self.top.listen("V", RHColumnFocuser(0))
         self.top.listen("S", RHColumnFocuser(1))
         self.top.listen("B", RHColumnFocuser(2))
+        self.top.listen("ctrl ^", toggle_sidebar)
 
         self.top.listen("q", quit)
         self.top.listen("ctrl p", do_edit_config)
@@ -1859,6 +1870,13 @@ class DebuggerUI(FrameVarInfoKeeper):
         w = Attr(w, "background")
 
         return self.event_loop(w)[0]
+
+    def _toggle_sidebar(self, visible):
+        if visible:
+            self.columns.column_types[1] = "weight", float(CONFIG["sidebar_width"])
+        else:
+            self.columns.column_types[1] = "given", 0
+        self.columns._invalidate()
 
     @staticmethod
     def setup_palette(screen):

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -76,6 +76,7 @@ def load_config():
     conf_dict.setdefault("wrap_variables", True)
 
     conf_dict.setdefault("display", "auto")
+    conf_dict.setdefault("sidebar_visible", True)
 
     conf_dict.setdefault("prompt_on_quit", True)
 
@@ -91,6 +92,7 @@ def load_config():
     normalize_bool_inplace("line_numbers")
     normalize_bool_inplace("wrap_variables")
     normalize_bool_inplace("prompt_on_quit")
+    normalize_bool_inplace("sidebar_visible")
 
     return conf_dict
 


### PR DESCRIPTION
I wanted to add support to copy pudb console output to the clipboard. Unfortunately, python libraries such as tkinter or pyclipboard rely on external modules to provide clipboard support, which makes this feature difficult to provide reliably.

As I work around, I have added support to hide the sidebar using ctrl ^. When the sidebar is not visible you can select multiple lines of text in the console without selecting text from the sidebar.