### PR TITLE
[ipython] Fix IPython miss match version

### DIFF
--- a/pudb/shell.py
+++ b/pudb/shell.py
@@ -1,6 +1,6 @@
 try:
     import IPython
-except ImportError:
+except (ImportError, ValueError):
     HAVE_IPYTHON = False
 else:
     HAVE_IPYTHON = True


### PR DESCRIPTION
If IPython system version missmatches the one we expect with pudb then
it will throw a ValueError when we try to import it, that says we need a
fallback mode, this exception can be handled and simply disable IPython