### PR TITLE
Expand variables for custom theme path

### DIFF
--- a/pudb/theme.py
+++ b/pudb/theme.py
@@ -522,8 +522,8 @@ def get_palette(may_use_fancy_formats, theme="classic"):
                     "add_setting": add_setting,
                     }
 
-            from os.path import expanduser
-            execfile(expanduser(theme), symbols)
+            from os.path import expanduser, expandvars
+            execfile(expanduser(expandvars(theme)), symbols)
         except:
             print("Error when importing theme:")
             from traceback import print_exc


### PR DESCRIPTION
For those who want to use environment variables (eg: $XDG_CONFIG_HOME) in a custom theme's path.