### PR TITLE
wheel: disable universal flag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 ignore = E126,E127,E128,E123,E226,E241,E242,E265,W503,E402
 max-line-length=85
 [wheel]
-universal = 1
+universal = 0


### PR DESCRIPTION
Currently, universal flag is enabled in setup.cfg.
https://github.com/inducer/pudb/blob/v2015.4.1/setup.cfg#L5

Therefore, setup.py generates universal (= python 2/3 compatible) wheel.
```
$ python --version
Python 3.3.6
$ python setup.py bdist_wheel
$ ls dist
pudb-2015.4.1-py2.py3-none-any.whl
```

However, pudb can't build universal wheel strictly.

When trying to install to python2 environment.
```
$ python --version
Python 2.7.10
$ pip install dist/pudb-2015.4.1-py2.py3-none-any.whl
```

Suffix of '3' is appended to installed command.
```
$ pudb3
Usage: pudb3 [options] SCRIPT-TO-RUN [SCRIPT-ARGUMENTS]

Options:
  -h, --help          show this help message and exit
  -s, --steal-output
  --pre-run=COMMAND   Run command before each program run
```

Because wheel was built by python3 environment.

The command name is fixed by the timing of to build wheel.
https://github.com/inducer/pudb/blob/v2015.4.1/setup.py#L55