### PR TITLE
regularlize whitespace for multiline strings

### DIFF
--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -195,7 +195,7 @@ def edit_config(ui, conf_dict):
         "Configuration settings are saved in "
         "$HOME/.config/pudb or $XDG_CONFIG_HOME/pudb "
         "environment variable. If both variables are not set "
-        " configurations settings will not be saved.\n")
+        "configurations settings will not be saved.\n")
 
     cb_line_numbers = urwid.CheckBox("Show Line Numbers",
             bool(conf_dict["line_numbers"]), on_state_change=_update_config,

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -250,7 +250,7 @@ def get_stringifier(iinfo):
             return lambda value: "ERROR: Invalid custom stringifier file."
         else:
             if "pudb_stringifier" not in custom_stringifier_dict:
-                print("%s does not contain a function named pudb_stringifier at"
+                print("%s does not contain a function named pudb_stringifier at "
                       "the module level." % iinfo.display_type)
                 raw_input("Hit enter:")
                 return lambda value: ("ERROR: Invalid custom stringifier file: "


### PR DESCRIPTION
Include a trailing space on the first line.
Omit leading space on following line.