### PR TITLE
Ensure var view never splits Unicode chars

### DIFF
--- a/pudb/ui_tools.py
+++ b/pudb/ui_tools.py
@@ -1,4 +1,5 @@
 import urwid
+from urwid.util import _target_encoding
 
 
 # generic urwid helpers -------------------------------------------------------
@@ -22,9 +23,20 @@ def make_canvas(txt, attr, maxcol, fill_attr=None):
             line_attr = rle_subseg(line_attr, 0, maxcol)
 
         from urwid.util import apply_target_encoding
-        line, line_cs = apply_target_encoding(line)
+        encoded_line, line_cs = apply_target_encoding(line)
 
-        processed_txt.append(line)
+        # line_cs contains byte counts as requested by TextCanvas, but
+        # line_attr still contains column counts at this point: let's fix this.
+        def get_byte_line_attr(line, line_attr):
+            i = 0
+            for label, column_count in line_attr:
+                byte_count = len(line[i:column_count].encode(_target_encoding))
+                i += column_count
+                yield label, byte_count
+
+        line_attr = list(get_byte_line_attr(line, line_attr))
+
+        processed_txt.append(encoded_line)
         processed_attr.append(line_attr)
         processed_cs.append(line_cs)
 


### PR DESCRIPTION
TextCanvas wants byte counts, but we were sending column counts. It does
fix the immediate issue, but when a given variable is so long that we
need to scroll, there are now some dangling characters after the final
quote, even when the variable only contains ASCII.

This imports a private variable from urwid.util to avoid depending too
much on apply_target_encoding magic - not sure if a good idea.