### PR TITLE
Fix make_canvas for lines with multiple attrs

### DIFF
--- a/pudb/ui_tools.py
+++ b/pudb/ui_tools.py
@@ -30,7 +30,7 @@ def make_canvas(txt, attr, maxcol, fill_attr=None):
         def get_byte_line_attr(line, line_attr):
             i = 0
             for label, column_count in line_attr:
-                byte_count = len(line[i:column_count].encode(_target_encoding))
+                byte_count = len(line[i:i+column_count].encode(_target_encoding))
                 i += column_count
                 yield label, byte_count
 

--- a/unittests/test_make_canvas.py
+++ b/unittests/test_make_canvas.py
@@ -1,0 +1,45 @@
+from pudb.ui_tools import make_canvas
+
+class TestMakeCanvas():
+    def test_simple(self):
+        text = u'aaaaaa'
+        canvas = make_canvas(
+            txt=[text],
+            attr=[[('var value', len(text))]],
+            maxcol=len(text) + 5
+        )
+        content = list(canvas.content())
+        assert content == [
+            [('var value', None, b'aaaaaa'), (None, None, b' ' * 5)]
+        ]
+
+    def test_multiple(self):
+        canvas = make_canvas(
+            txt=[u'Return: None'],
+            attr=[[('return label', 8), ('return value', 4)]],
+            maxcol=100
+        )
+        content = list(canvas.content())
+        assert content == [
+            [('return label', None, b'Return: '),
+             ('return value', None, b'None'),
+             (None, None, b' ' * 88)]
+        ]
+
+    def test_boundary(self):
+        text = u'aaaaaa'
+        canvas = make_canvas(
+            txt=[text],
+            attr=[[('var value', len(text))]],
+            maxcol=len(text)
+        )
+        assert list(canvas.content()) == [[('var value', None, b'aaaaaa')]]
+
+    def test_byte_boundary(self):
+        text = u'aaaaaaé'
+        canvas = make_canvas(
+            txt=[text],
+            attr=[[('var value', len(text))]],
+            maxcol=len(text)
+        )
+        assert list(canvas.content()) == [[('var value', None, b'aaaaaa\xc3\xa9')]]


### PR DESCRIPTION
As I was saying in #174, I was seeing some dangling characters issue. The issue was more severe than that, because I was always using `line[i:count]` instead of `line[i:i+count]`. To ensure this two chars fix works I added unit tests. They can be run by using 'py.test' from the root pudb directory.