### PR TITLE
Fixed issue with debugging apps with non-ascii data

### DIFF
--- a/pudb/remote.py
+++ b/pudb/remote.py
@@ -69,9 +69,17 @@ class RemoteDebugger(Debugger):
         # makefile ignores encoding if there's no buffering.
         raw_sock_file = self._client.makefile("rwb", 0)
         import codecs
-        sock_file = codecs.StreamRecoder(raw_sock_file,
+
+        if sys.version_info[0] < 3:
+            sock_file = codecs.StreamRecoder(
+                raw_sock_file,
                 codecs.getencoder("utf-8"),
                 codecs.getdecoder("utf-8"),
+                codecs.getreader("utf-8"),
+                codecs.getwriter("utf-8"))
+        else:
+            sock_file = codecs.StreamReaderWriter(
+                raw_sock_file,
                 codecs.getreader("utf-8"),
                 codecs.getwriter("utf-8"))
 

--- a/pudb/remote.py
+++ b/pudb/remote.py
@@ -69,7 +69,9 @@ class RemoteDebugger(Debugger):
         # makefile ignores encoding if there's no buffering.
         raw_sock_file = self._client.makefile("rwb", 0)
         import codecs
-        sock_file = codecs.StreamReaderWriter(raw_sock_file,
+        sock_file = codecs.StreamRecoder(raw_sock_file,
+                codecs.getencoder("utf-8"),
+                codecs.getdecoder("utf-8"),
                 codecs.getreader("utf-8"),
                 codecs.getwriter("utf-8"))
 


### PR DESCRIPTION
Currently, there is an issue with remote debugging apps which have non-ascii data (in variables, for example):


```
# -*- coding: utf-8 -*-

from pudb.remote import set_trace

d = {'key': 'żółta jaźń'}

set_trace(term_size=(80, 24))
```

Originally fails with:

```
  File "/usr/lib/python2.7/bdb.py", line 49, in trace_dispatch
    return self.dispatch_line(frame)
  File "/home/m/Projekty/test/local/lib/python2.7/site-packages/pudb/debugger.py", line 173, in dispatch_line
    self.user_line(frame)
  File "/home/m/Projekty/test/local/lib/python2.7/site-packages/pudb/debugger.py", line 376, in user_line
    self.interaction(frame)
  File "/home/m/Projekty/test/local/lib/python2.7/site-packages/pudb/debugger.py", line 344, in interaction
    show_exc_dialog=show_exc_dialog)
  File "/home/m/Projekty/test/local/lib/python2.7/site-packages/pudb/debugger.py", line 2084, in call_with_ui
    return f(*args, **kwargs)
  File "/home/m/Projekty/test/local/lib/python2.7/site-packages/pudb/debugger.py", line 2301, in interaction
    self.event_loop()
  File "/home/m/Projekty/test/local/lib/python2.7/site-packages/pudb/debugger.py", line 2260, in event_loop
    self.screen.draw_screen(self.size, canvas)
  File "/home/m/Projekty/test/local/lib/python2.7/site-packages/urwid/raw_display.py", line 838, in draw_screen
    self.write(l)
  File "/home/m/Projekty/test/local/lib/python2.7/site-packages/urwid/raw_display.py", line 268, in write
    self._term_output_file.write(data)
  File "/home/m/Projekty/test/lib/python2.7/codecs.py", line 706, in write
    return self.writer.write(data)
  File "/home/m/Projekty/test/lib/python2.7/codecs.py", line 369, in write
    data, consumed = self.encode(object, self.errors)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 1: ordinal not in range(128)
```

I suspect its because StreamReaderWriter is using default encoder and decoder which is "ascii". After fixing encoder and decoder, example case works fine.
