### PR TITLE
Avoid trying to use IPython unless it seems like it is present

### DIFF
--- a/pudb/shell.py
+++ b/pudb/shell.py
@@ -96,12 +96,19 @@ def have_ipython():
     # https://github.com/ipython/ipython/issues/9435
 
     try:
+        # Assume don't have IronPython unless this variable is
+        # defined, see:
+        # http://stackoverflow.com/questions/5376837/run-from-ipython
+        # this skips the pain of demandimporters when IPython
+        # is available but not actually active:
+        # https://bz.mercurial-scm.org/show_bug.cgi?id=5346
+        __IPYTHON__
         import IPython
         # Access a property to verify module exists in case
         # there's a demand loader wrapping module imports
         # See https://github.com/inducer/pudb/issues/177
         IPython.core
-    except (ImportError, ValueError):
+    except (NameError, ImportError, ValueError):
         # Old IPythons versions (0.12?) may fail to import with
         # ValueError: fallback required, but not specified
         # https://github.com/inducer/pudb/pull/135


### PR DESCRIPTION
`__IPYTHON__` was apparently removed from only 0.11,
and then the developers got negative feedback and restored it
for 0.12:
https://github.com/ipython/ipython/pull/1059

Various versions of IPython break demand loaders badly.
The current version is 5.1 or thereabouts, I am using 4.x.

It is unlikely that someone would be using 0.11 (July 2011),
so look for this variable first.

I know, this is not the first time we've tried to address IPython. The previous attempt dies as some part of IPython tries to do something that the demand loader isn't expecting. (And the demandloader people thought they'd fixed IPython). This approach works.