### PR TITLE
Fix module reloading

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1375,10 +1375,10 @@ class DebuggerUI(FrameVarInfoKeeper):
                         mod_name = widget.base_widget.get_text()[0]
                         mod = sys.modules[mod_name]
                         if PY3:
-                            reload(mod)  # noqa (undef on Py3)
-                        else:
                             import importlib
                             importlib.reload(mod)
+                        else:
+                            reload(mod)  # noqa (undef on Py3)
 
                         self.message("'%s' was successfully reloaded." % mod_name)
 


### PR DESCRIPTION
The Python 2/3 check was reversed from what it was supposed to be.

FWIW, the reload button is confusing. It reloads the selected module, even though it isn't selected any more if you arrow over to button. I would have expected it to reload the list.  And what is the benefit of reloading a module anyway? 