### PR TITLE
redraw the whole screen when switching themes

### DIFF
--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -126,9 +126,7 @@ def edit_config(ui, conf_dict):
 
     def _update_theme():
         ui.setup_palette(ui.screen)
-
-        for sl in ui.source:
-            sl._invalidate()
+        ui.screen.clear()
 
     def _update_line_numbers():
         for sl in ui.source:


### PR DESCRIPTION
Currently, when selecting a new theme in the settings menu, only two lines get updated with the new theme. This redraw the whole screen with the new theme.