### PR TITLE
Updating access to bpython version

### DIFF
--- a/pudb/.vimcache/ctrlp/mru/cache.txt
+++ b/pudb/.vimcache/ctrlp/mru/cache.txt
@@ -1,0 +1,1 @@
+/work/shell.py

--- a/pudb/.vimcache/ctrlp/mru/cache.txt
+++ b/pudb/.vimcache/ctrlp/mru/cache.txt
@@ -1,1 +1,0 @@
-/work/shell.py

--- a/pudb/shell.py
+++ b/pudb/shell.py
@@ -5,7 +5,10 @@ try:
     # Access a property to verify module exists in case
     # there's a demand loader wrapping module imports
     # See https://github.com/inducer/pudb/issues/177
-    bpython.__version__
+    if hasattr(bpython, 'version'):
+        bpython.version
+    else:
+        bpython.__version__
 except ImportError:
     HAVE_BPYTHON = False
 else:

--- a/pudb/shell.py
+++ b/pudb/shell.py
@@ -5,7 +5,7 @@ try:
     # Access a property to verify module exists in case
     # there's a demand loader wrapping module imports
     # See https://github.com/inducer/pudb/issues/177
-    bpython.version
+    bpython.__version__
 except ImportError:
     HAVE_BPYTHON = False
 else:


### PR DESCRIPTION
I don't know if this the correct way to do this but to get bpython working with my version of pudb I had to change this variable or else I was getting errors saying:

```
bpython.version
AttributeError: 'module' object has no attribute 'version'
```

After changing the snippet everything seemed to work fine. 