### PR TITLE
Monokai

### DIFF
--- a/pudb/source_view.py
+++ b/pudb/source_view.py
@@ -157,9 +157,11 @@ def format_source(debugger_ui, lines, breakpoints):
                 t.Token: "source",
                 t.Keyword.Namespace: "namespace",
                 t.Token.Argument: "argument",
+                t.Token.Dunder: "dunder",
+                t.Token.Keyword2: 'keyword2',
                 t.Keyword: "keyword",
                 t.Literal: "literal",
-                t.Name.Exception: "keyword",
+                t.Name.Exception: "exception",
                 t.Name.Function: "name",
                 t.Name.Class: "name",
                 t.Name.Builtin: "builtin",
@@ -178,13 +180,11 @@ def format_source(debugger_ui, lines, breakpoints):
 
         ATTR_TRANSLATE = {
                 t.Keyword: {
-                    'try': t.Operator.Word,
-                    'except': t.Operator.Word,
-                    'pass': t.Operator.Word,
-                    'return': t.Operator.Word,
-                    'for': t.Operator.Word,
-                    'if': t.Operator.Word,
-                    'yield': t.Operator.Word,
+                    'class': t.Token.Keyword2,
+                    'def': t.Token.Keyword2,
+                    'exec': t.Token.Keyword2,
+                    'lambda': t.Token.Keyword2,
+                    'print': t.Token.Keyword2,
                     },
                 t.Operator:{
                     '.': t.Token,
@@ -195,9 +195,6 @@ def format_source(debugger_ui, lines, breakpoints):
                 t.Name.Builtin:{
                     'object': t.Name.Class,
                     },
-                # t.Name:{
-                #     'a': t.Token.Argument, # For Debug testing of argument parsing
-                #     }
                 }
 
         class UrwidFormatter(Formatter):
@@ -214,7 +211,7 @@ def format_source(debugger_ui, lines, breakpoints):
 
                     # Find function arguments. When found, set their
                     # ttype to t.Token.Argument
-                    new_ttype= argument_parser.parse_token(ttype, s)
+                    new_ttype = argument_parser.parse_token(ttype, s)
                     if new_ttype:
                         ttype = new_ttype
 
@@ -224,7 +221,7 @@ def format_source(debugger_ui, lines, breakpoints):
                             ttype = ATTR_TRANSLATE[ttype][s]
                     # Translate dunder methods to buitins
                     if ttype == t.Name.Function and s.startswith('__') and s.endswith('__'):
-                        ttype = t.Name.Builtin
+                        ttype = t.Token.Dunder
 
                     while not ttype in ATTR_MAP:
                         if ttype.parent is not None:

--- a/pudb/source_view.py
+++ b/pudb/source_view.py
@@ -279,14 +279,13 @@ def format_source(debugger_ui, lines, breakpoints):
 
         return result
 
-from enum import Enum
-class ParseState(Enum):
+class ParseState(object):
     '''States for the ArgumentParser class'''
     idle = 1
     found_function = 2
     found_open_paren = 3
 
-class AgumentParser():
+class AgumentParser(object):
     '''Parse source code tokens and identify function arguments.
 
     This parser implements a state machine which accepts

--- a/pudb/source_view.py
+++ b/pudb/source_view.py
@@ -151,7 +151,7 @@ def format_source(debugger_ui, lines, breakpoints):
         import pygments.token as t
 
         result = []
-        argument_parser = AgumentParser(t)
+        argument_parser = ArgumentParser(t)
 
         # NOTE: Tokens of the form t.Token.<name> are not native
         #       Pygments token types; they are user defined token
@@ -285,14 +285,14 @@ class ParseState(object):
     found_function = 2
     found_open_paren = 3
 
-class AgumentParser(object):
+class ArgumentParser(object):
     '''Parse source code tokens and identify function arguments.
 
     This parser implements a state machine which accepts
     Pygments tokens, delivered sequentially from the beginning
-    of a source file to it's end.
+    of a source file to its end.
 
-    parse_token() processes each token (and it's associated string)
+    parse_token() processes each token (and its associated string)
     and returns None if that token does not require modification.
     When it finds a token which represents a function
     argument, it returns the correct token type for that

--- a/pudb/theme.py
+++ b/pudb/theme.py
@@ -567,7 +567,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "argument": ("light blue", "default"),
             "builtin": ("dark green", "default"),
             "pseudo": ("light blue", "default"),
-            "dunder": ("light cyan", "black"),
+            "dunder": ("light blue", "default"),
             "keyword": ("dark green", "default"),
             "exception": ("light blue", "default"),
 

--- a/pudb/theme.py
+++ b/pudb/theme.py
@@ -14,6 +14,22 @@ def get_palette(may_use_fancy_formats, theme="classic"):
         def add_setting(color, setting):
             return color
 
+    #-----------------------------------------------------------------------------------
+    # Reference for some palette items:
+    #
+    #  "namespace" : "import", "from", "using"
+    #  "operator"  : "+", "-", "=" etc.
+    #                NOTE: Does not include ".", which is assigned the type "source"
+    #  "argument"  : Function arguments
+    #  "builtin"   : "range", "dict", "set", "list", etc.
+    #  "pseudo"    : "None", "True", "False"
+    #                NOTE: Does not include "self", which is assigned the type "source"
+    #  "dunder"    : Class method names of the form __<name>__ within a class definition
+    #  "keyword"   : All keywords except those specifically assigned to "keyword2"
+    #                ("from", "and", "break", "is", "try", "pass", etc.)
+    #  "keyword2"  : "class", "def", "exec", "lambda", "print"
+    #-----------------------------------------------------------------------------------
+
     palette_dict = { # {{{ ui
 
         "header": ("black", "light gray", "standout"),

--- a/pudb/theme.py
+++ b/pudb/theme.py
@@ -776,7 +776,12 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "current highlighted source": ("white", "dark cyan"),
 
             "line number": ("dark gray", "black"),
-            "keyword": ("light red", "black"),
+            "namespace": ("light red", "black"),
+            "keyword": ("light cyan", "black"),
+            "builtin": ("light cyan", "black"),
+            "pseudo": ("light magenta", "black"),
+            "operator": ("light red", "black"),
+            "argument": ("yellow", "black"),
 
             "literal": ("light magenta", "black"),
             "string": ("yellow", "black"),
@@ -913,7 +918,12 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "current highlighted source": ("h255", "h22"),
 
             "line number": ("h241", "h235"),
-            "keyword": ("h198", "h235"),
+            "namespace": ("h198", "h235"),
+            "keyword": ("h51", "h235"),
+            "builtin": ("h51", "h235"),
+            "pseudo": ("h141", "h235"),
+            "operator": ("h198", "h235"),
+            "argument": ("h208", "h235"),
 
             "literal": ("h141", "h235"),
             "string": ("h228", "h235"),

--- a/pudb/theme.py
+++ b/pudb/theme.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-THEMES = ["classic", "vim", "dark vim", "midnight", "solarized", "agr-256"]
+THEMES = ["classic", "vim", "dark vim", "midnight", "solarized", "agr-256", "monokai", "monokai-256"]
 
 from pudb.py3compat import execfile, raw_input
 import urwid
@@ -436,7 +436,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
 
         # }}}
     elif theme == "solarized":
-    # {{{ solarized
+        # {{{ solarized
         palette_dict.update({
             # UI
             "header": ("black", "light blue", "standout"),
@@ -537,9 +537,9 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "command line focused button": ("black", "light blue"),
         })
 
-    # }}}
+        # }}}
     elif theme == "agr-256":
-    # {{{ agr-256
+        # {{{ agr-256
         palette_dict.update({
             "header": ("h235", "h252", "standout"),
 
@@ -666,7 +666,284 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "command line focused button": ("h255", "h24"),
             # }}}
         })
-    # }}}
+        # }}}
+    elif theme == "monokai":
+        # {{{ monokai
+        palette_dict.update({
+            "header": ("black", "light gray", "standout"),
+
+            # {{{ variables view
+            "variables": ("black", "dark gray"),
+            "variable separator": ("dark cyan", "light gray"),
+
+            "var label": ("light gray", "dark gray"),
+            "var value": ("white", "dark gray"),
+            "focused var label": ("light gray", "light blue"),
+            "focused var value": ("white", "light blue"),
+
+            "highlighted var label": ("light gray", "dark green"),
+            "highlighted var value": ("white", "dark green"),
+            "focused highlighted var label": ("light gray", "light blue"),
+            "focused highlighted var value": ("white", "light blue"),
+
+            "return label": ("light gray", "dark gray"),
+            "return value": ("light cyan", "dark gray"),
+            "focused return label": ("yellow", "light blue"),
+            "focused return value": ("white", "light blue"),
+
+            # }}}
+
+            # {{{ stack view
+
+            "stack": ("black", "dark gray"),
+
+            "frame name": ("light gray", "dark gray"),
+            "focused frame name": ("light gray", "light blue"),
+            "frame class": ("dark blue", "dark gray"),
+            "focused frame class": ("dark blue", "light blue"),
+            "frame location": ("white", "dark gray"),
+            "focused frame location": ("white", "light blue"),
+
+            "current frame name": (add_setting("white", "bold"),
+                "dark gray"),
+            "focused current frame name": (add_setting("white", "bold"),
+                "light blue", "bold"),
+            "current frame class": ("dark blue", "dark gray"),
+            "focused current frame class": ("dark blue", "dark green"),
+            "current frame location": ("light cyan", "dark gray"),
+            "focused current frame location": ("light cyan", "light blue"),
+
+            # }}}
+
+            # {{{ breakpoint view
+
+            "breakpoint": ("light gray", "dark gray"),
+            "disabled breakpoint": ("black", "dark gray"),
+            "focused breakpoint": ("light gray", "light blue"),
+            "focused disabled breakpoint": ("black", "light blue"),
+            "current breakpoint": (add_setting("white", "bold"), "dark gray"),
+            "disabled current breakpoint": ("black", "dark gray"),
+            "focused current breakpoint":
+                (add_setting("white", "bold"), "light blue"),
+            "focused disabled current breakpoint":
+                ("black", "light blue"),
+
+            # }}}
+
+            # {{{ ui widgets
+
+            "selectable": ("light gray", "dark gray"),
+            "focused selectable": ("white", "light blue"),
+
+            "button": ("light gray", "dark gray"),
+            "focused button": ("white", "light blue"),
+
+            "background": ("black", "light gray"),
+            "hotkey": (add_setting("black", "underline"), "light gray", "underline"),
+            "focused sidebar": ("light blue", "light gray", "standout"),
+
+            "warning": (add_setting("white", "bold"), "dark red", "standout"),
+
+            "label": ("black", "light gray"),
+            "value": ("white", "dark gray"),
+            "fixed value": ("light gray", "dark gray"),
+
+            "search box": ("white", "dark gray"),
+            "search not found": ("white", "dark red"),
+
+            "dialog title": (add_setting("white", "bold"), "dark gray"),
+
+            # }}}
+
+            # {{{ source view
+
+            "breakpoint marker": ("dark red", "black"),
+
+            "breakpoint source": ("light gray", "dark red"),
+            "breakpoint focused source": ("black", "dark red"),
+            "current breakpoint source": ("black", "dark red"),
+            "current breakpoint focused source": ("white", "dark red"),
+
+            # }}}
+
+            # {{{ highlighting
+
+            "source": ("white", "black"),
+            "focused source": ("white", "light blue"),
+            "highlighted source": ("black", "dark magenta"),
+            "current source": ("black", "light gray"),
+            "current focused source": ("white", "dark cyan"),
+            "current highlighted source": ("white", "dark cyan"),
+
+            "line number": ("dark gray", "black"),
+            "keyword": ("light red", "black"),
+
+            "literal": ("light magenta", "black"),
+            "string": ("yellow", "black"),
+            "doublestring": ("yellow", "black"),
+            "singlestring": ("yellow", "black"),
+            "docstring": ("light gray", "black"),
+
+            "name": ("light green", "black"),
+            "punctuation": ("white", "black"),
+            "comment": ("light gray", "black"),
+
+            # }}}
+
+            # {{{ shell
+
+            "command line edit":
+            ("white", "black"),
+            "command line prompt":
+            (add_setting("yellow", "bold"), "black"),
+
+            "command line output":
+            (add_setting("yellow", "bold"), "black"),
+            "command line input":
+            ("white", "black"),
+            "command line error":
+            (add_setting("light red", "bold"), "black"),
+
+            "focused command line output":
+            ("black", "light blue"),
+            "focused command line input":
+            (add_setting("light cyan", "bold"), "light blue"),
+            "focused command line error":
+            ("black", "light blue"),
+
+            # }}}
+            })
+
+        # }}}
+    elif theme == "monokai-256":
+        # {{{ monokai-256
+        palette_dict.update({
+            "header": ("h235", "h252", "standout"),
+
+            # {{{ variables view
+            "variables": ("h235", "h233"),
+            "variable separator": ("h23", "h252"),
+
+            "var label": ("h111", "h233"),
+            "var value": ("h255", "h233"),
+            "focused var label": ("h237", "h172"),
+            "focused var value": ("h237", "h172"),
+
+            "highlighted var label": ("h252", "h22"),
+            "highlighted var value": ("h255", "h22"),
+            "focused highlighted var label": ("h252", "h64"),
+            "focused highlighted var value": ("h255", "h64"),
+
+            "return label": ("h113", "h233"),
+            "return value": ("h113", "h233"),
+            "focused return label": (add_setting("h192", "bold"), "h24"),
+            "focused return value": ("h237", "h172"),
+            # }}}
+
+            # {{{ stack view
+            "stack": ("h235", "h233"),
+
+            "frame name": ("h192", "h233"),
+            "focused frame name": ("h237", "h172"),
+            "frame class": ("h111", "h233"),
+            "focused frame class": ("h237", "h172"),
+            "frame location": ("h252", "h233"),
+            "focused frame location": ("h237", "h172"),
+
+            "current frame name": ("h255", "h22"),
+            "focused current frame name": ("h255", "h64"),
+            "current frame class": ("h111", "h22"),
+            "focused current frame class": ("h255", "h64"),
+            "current frame location": ("h252", "h22"),
+            "focused current frame location": ("h255", "h64"),
+            # }}}
+
+            # {{{ breakpoint view
+            "breakpoint": ("h80", "h233"),
+            "disabled breakpoint": ("h60", "h233"),
+            "focused breakpoint": ("h237", "h172"),
+            "focused disabled breakpoint": ("h182", "h24"),
+            "current breakpoint": (add_setting("h255", "bold"), "h22"),
+            "disabled current breakpoint": (add_setting("h016", "bold"), "h22"),
+            "focused current breakpoint": (add_setting("h255", "bold"), "h64"),
+            "focused disabled current breakpoint": (add_setting("h016", "bold"), "h64"),
+            # }}}
+
+            # {{{ ui widgets
+
+            "selectable": ("h252", "h235"),
+            "focused selectable": ("h255", "h24"),
+
+            "button": ("h252", "h235"),
+            "focused button": ("h255", "h24"),
+
+            "background": ("h235", "h252"),
+            "hotkey": (add_setting("h235", "underline"), "h252", "underline"),
+            "focused sidebar": ("h23", "h252", "standout"),
+
+            "warning": (add_setting("h255", "bold"), "h124", "standout"),
+
+            "label": ("h235", "h252"),
+            "value": ("h255", "h17"),
+            "fixed value": ("h252", "h17"),
+            "group head": (add_setting("h25", "bold"), "h252"),
+
+            "search box": ("h255", "h235"),
+            "search not found": ("h255", "h124"),
+
+            "dialog title": (add_setting("h255", "bold"), "h235"),
+
+            # }}}
+
+            # {{{ source view
+            "breakpoint marker": ("h160", "h235"),
+
+            "breakpoint source": ("h252", "h124"),
+            "breakpoint focused source": ("h192", "h124"),
+            "current breakpoint source": ("h192", "h124"),
+            "current breakpoint focused source": (add_setting("h192", "bold"), "h124"),
+            # }}}
+
+            # {{{ highlighting
+            "source": ("h255", "h235"),
+            "focused source": ("h237", "h172"),
+            "highlighted source": ("h252", "h22"),
+            "current source": (add_setting("h252", "bold"), "h23"),
+            "current focused source": (add_setting("h192", "bold"), "h23"),
+            "current highlighted source": ("h255", "h22"),
+
+            "line number": ("h241", "h235"),
+            "keyword": ("h198", "h235"),
+
+            "literal": ("h141", "h235"),
+            "string": ("h228", "h235"),
+            "doublestring": ("h228", "h235"),
+            "singlestring": ("h228", "h235"),
+            "docstring": ("h243", "h235"),
+
+            "name": ("h155", "h235"),
+            "punctuation": ("h255", "h235"),
+            "comment": ("h243", "h235"),
+
+            # }}}
+
+            # {{{ shell
+            "command line edit": ("h255", "h233"),
+            "command line prompt": (add_setting("h192", "bold"), "h233"),
+
+            "command line output": ("h80", "h233"),
+            "command line input": ("h255", "h233"),
+            "command line error": ("h160", "h233"),
+
+            "focused command line output": (add_setting("h192", "bold"), "h24"),
+            "focused command line input": ("h255", "h24"),
+            "focused command line error": ("h235", "h24"),
+
+            "command line clear button": (add_setting("h255", "bold"), "h233"),
+            "command line focused button": ("h255", "h24"),
+            # }}}
+        })
+        # }}}
 
     else:
         try:

--- a/pudb/theme.py
+++ b/pudb/theme.py
@@ -81,9 +81,18 @@ def get_palette(may_use_fancy_formats, theme="classic"):
         # {{{ highlighting
 
         "line number": ("light gray", "dark blue"),
-        "keyword": (add_setting("white", "bold"), "dark blue"),
+        "keyword2": (add_setting("white", "bold"), "dark blue"),
         "name": ("light cyan", "dark blue"),
         "literal": ("light magenta, bold", "dark blue"),
+
+        "namespace": (add_setting("white", "bold"), "dark blue"),
+        "operator": (add_setting("yellow", "bold"), "dark blue"),
+        "argument": (add_setting("yellow", "bold"), "dark blue"),
+        "builtin": (add_setting("yellow", "bold"), "dark blue"),
+        "pseudo": (add_setting("yellow", "bold"), "dark blue"),
+        "dunder": ("light cyan", "dark blue"),
+        "keyword": (add_setting("white", "bold"), "dark blue"),
+        "exception": (add_setting("yellow", "bold"), "dark blue"),
 
         "string": (add_setting("light magenta", "bold"), "dark blue"),
         "doublestring": (add_setting("light magenta", "bold"), "dark blue"),
@@ -161,7 +170,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
 
         palette_dict.update({
             "source": ("black", "default"),
-            "keyword": ("brown", "default"),
+            "keyword2": ("brown", "default"),
             "kw_namespace": ("dark magenta", "default"),
 
             "literal": ("black", "default"),
@@ -176,6 +185,15 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "name": ("dark cyan", "default"),
             "line number": ("dark gray", "default"),
             "breakpoint marker": ("dark red", "default"),
+
+            "namespace": ("brown", "default"),
+            "operator": ("black", "default"),
+            "argument": ("black", "default"),
+            "builtin": ("black", "default"),
+            "pseudo": ("black", "default"),
+            "dunder": ("dark cyan", "default"),
+            "keyword": ("brown", "default"),
+            "exception": ("black", "default"),
 
             # {{{ shell
 
@@ -311,7 +329,16 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "current highlighted source": ("white", "dark cyan"),
 
             "line number": ("dark gray", "black"),
+            "keyword2": ("yellow", "black"),
+
+            "namespace": ("yellow", "black"),
+            "operator": ("white", "black"),
+            "argument": ("white", "black"),
+            "builtin": ("white", "black"),
+            "pseudo": ("white", "black"),
+            "dunder": ("light cyan", "black"),
             "keyword": ("yellow", "black"),
+            "exception": ("white", "black"),
 
             "literal": ("dark magenta", "black"),
             "string": ("dark magenta", "black"),
@@ -398,7 +425,17 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "current focused source": ("white", "brown"),
 
             "line number": ("light gray", "default"),
+            "keyword2": ("dark magenta", "default"),
+
+            "namespace": ("dark magenta", "default"),
+            "operator": ("white", "default"),
+            "argument": ("white", "default"),
+            "builtin": ("dark magenta", "default"),
+            "pseudo": ("white", "default"),
+            "dunder": ("white", "default"),
             "keyword": ("dark magenta", "default"),
+            "exception": ("white", "default"),
+
             "name": ("white", "default"),
             "literal": ("dark cyan", "default"),
             "string": ("dark red", "default"),
@@ -507,7 +544,17 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "highlighted source": ("light blue", "black"),
 
             "line number": ("light blue", "default"),
+            "keyword2": ("dark green", "default"),
+
+            "namespace": ("dark green", "default"),
+            "operator": ("light blue", "default"),
+            "argument": ("light blue", "default"),
+            "builtin": ("dark green", "default"),
+            "pseudo": ("light blue", "default"),
+            "dunder": ("light cyan", "black"),
             "keyword": ("dark green", "default"),
+            "exception": ("light blue", "default"),
+
             "name": ("light blue", "default"),
             "literal": ("dark cyan", "default"),
             "string": ("dark cyan", "default"),
@@ -636,15 +683,24 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "current highlighted source": ("h255", "h22"),
 
             "line number": ("h241", "h235"),
-            "keyword": ("h111", "h235"),
-
+            "keyword2": ("h111", "h235"),
+            "name": ("h192", "h235"),
             "literal": ("h173", "h235"),
+
+            "namespace": ("h111", "h235"),
+            "operator": ("h255", "h235"),
+            "argument": ("h255", "h235"),
+            "builtin": ("h255", "h235"),
+            "pseudo": ("h255", "h235"),
+            "dunder": ("h192", "h235"),
+            "keyword": ("h111", "h235"),
+            "exception": ("h255", "h235"),
+
             "string": ("h113", "h235"),
             "doublestring": ("h113", "h235"),
             "singlestring": ("h113", "h235"),
             "docstring": ("h113", "h235"),
 
-            "name": ("h192", "h235"),
             "punctuation": ("h223", "h235"),
             "comment": ("h246", "h235"),
 
@@ -776,20 +832,24 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "current highlighted source": ("white", "dark cyan"),
 
             "line number": ("dark gray", "black"),
+            "keyword2": ("light cyan", "black"),
+            "name": ("light green", "black"),
+            "literal": ("light magenta", "black"),
+            
             "namespace": ("light red", "black"),
-            "keyword": ("light cyan", "black"),
+            "operator": ("light red", "black"),
+            "argument": ("brown", "black"),
             "builtin": ("light cyan", "black"),
             "pseudo": ("light magenta", "black"),
-            "operator": ("light red", "black"),
-            "argument": ("yellow", "black"),
+            "dunder": ("light cyan", "black"),
+            "keyword": ("light red", "black"),
+            "exception": ("light cyan", "black"),
 
-            "literal": ("light magenta", "black"),
             "string": ("yellow", "black"),
             "doublestring": ("yellow", "black"),
             "singlestring": ("yellow", "black"),
             "docstring": ("light gray", "black"),
 
-            "name": ("light green", "black"),
             "punctuation": ("white", "black"),
             "comment": ("light gray", "black"),
 
@@ -918,20 +978,24 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "current highlighted source": ("h255", "h22"),
 
             "line number": ("h241", "h235"),
+            "keyword2": ("h51", "h235"),
+            "name": ("h155", "h235"),
+            "literal": ("h141", "h235"),
+
             "namespace": ("h198", "h235"),
-            "keyword": ("h51", "h235"),
-            "builtin": ("h51", "h235"),
-            "pseudo": ("h141", "h235"),
             "operator": ("h198", "h235"),
             "argument": ("h208", "h235"),
+            "builtin": ("h51", "h235"),
+            "pseudo": ("h141", "h235"),
+            "dunder": ("h51", "h235"),
+            "keyword": ("h198", "h235"),
+            "exception": ("h51", "h235"),
 
-            "literal": ("h141", "h235"),
             "string": ("h228", "h235"),
             "doublestring": ("h228", "h235"),
             "singlestring": ("h228", "h235"),
             "docstring": ("h243", "h235"),
 
-            "name": ("h155", "h235"),
             "punctuation": ("h255", "h235"),
             "comment": ("h243", "h235"),
 

--- a/pudb/theme.py
+++ b/pudb/theme.py
@@ -25,13 +25,41 @@ def get_palette(may_use_fancy_formats, theme="classic"):
     #  "pseudo"    : "None", "True", "False"
     #                NOTE: Does not include "self", which is assigned the type "source"
     #  "dunder"    : Class method names of the form __<name>__ within a class definition
+    #  "exception" : Exception names
     #  "keyword"   : All keywords except those specifically assigned to "keyword2"
     #                ("from", "and", "break", "is", "try", "pass", etc.)
     #  "keyword2"  : "class", "def", "exec", "lambda", "print"
     #-----------------------------------------------------------------------------------
 
-    palette_dict = { # {{{ ui
+    inheritance_map = (
+        # Style       Inherits from
+        # ----------  ----------
+        ("namespace", "keyword"),
+        ("operator",  "source"),
+        ("argument",  "source"),
+        ("builtin",   "source"),
+        ("pseudo",    "source"),
+        ("dunder",    "name"),
+        ("exception", "source"),
+        ("keyword2",  "keyword")
+    )
 
+    palette_dict = { 
+        # The following styles are initialized to "None".  Themes
+        # (including custom Themes) may set them as needed. 
+        # If they are not set by a theme, then they will
+        # inherit from other styles in accordance with
+        # the inheritance_map.
+        "namespace": None,
+        "operator":  None,
+        "argument":  None,
+        "builtin":   None,
+        "pseudo":    None,
+        "dunder":    None,
+        "exception": None,
+        "keyword2":  None,
+
+        # {{{ ui
         "header": ("black", "light gray", "standout"),
 
         "selectable": ("black", "dark cyan"),
@@ -97,18 +125,9 @@ def get_palette(may_use_fancy_formats, theme="classic"):
         # {{{ highlighting
 
         "line number": ("light gray", "dark blue"),
-        "keyword2": (add_setting("white", "bold"), "dark blue"),
+        "keyword": (add_setting("white", "bold"), "dark blue"),
         "name": ("light cyan", "dark blue"),
         "literal": ("light magenta, bold", "dark blue"),
-
-        "namespace": (add_setting("white", "bold"), "dark blue"),
-        "operator": (add_setting("yellow", "bold"), "dark blue"),
-        "argument": (add_setting("yellow", "bold"), "dark blue"),
-        "builtin": (add_setting("yellow", "bold"), "dark blue"),
-        "pseudo": (add_setting("yellow", "bold"), "dark blue"),
-        "dunder": ("light cyan", "dark blue"),
-        "keyword": (add_setting("white", "bold"), "dark blue"),
-        "exception": (add_setting("yellow", "bold"), "dark blue"),
 
         "string": (add_setting("light magenta", "bold"), "dark blue"),
         "doublestring": (add_setting("light magenta", "bold"), "dark blue"),
@@ -186,7 +205,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
 
         palette_dict.update({
             "source": ("black", "default"),
-            "keyword2": ("brown", "default"),
+            "keyword": ("brown", "default"),
             "kw_namespace": ("dark magenta", "default"),
 
             "literal": ("black", "default"),
@@ -201,15 +220,6 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "name": ("dark cyan", "default"),
             "line number": ("dark gray", "default"),
             "breakpoint marker": ("dark red", "default"),
-
-            "namespace": ("brown", "default"),
-            "operator": ("black", "default"),
-            "argument": ("black", "default"),
-            "builtin": ("black", "default"),
-            "pseudo": ("black", "default"),
-            "dunder": ("dark cyan", "default"),
-            "keyword": ("brown", "default"),
-            "exception": ("black", "default"),
 
             # {{{ shell
 
@@ -345,16 +355,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "current highlighted source": ("white", "dark cyan"),
 
             "line number": ("dark gray", "black"),
-            "keyword2": ("yellow", "black"),
-
-            "namespace": ("yellow", "black"),
-            "operator": ("white", "black"),
-            "argument": ("white", "black"),
-            "builtin": ("white", "black"),
-            "pseudo": ("white", "black"),
-            "dunder": ("light cyan", "black"),
             "keyword": ("yellow", "black"),
-            "exception": ("white", "black"),
 
             "literal": ("dark magenta", "black"),
             "string": ("dark magenta", "black"),
@@ -441,17 +442,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "current focused source": ("white", "brown"),
 
             "line number": ("light gray", "default"),
-            "keyword2": ("dark magenta", "default"),
-
-            "namespace": ("dark magenta", "default"),
-            "operator": ("white", "default"),
-            "argument": ("white", "default"),
-            "builtin": ("dark magenta", "default"),
-            "pseudo": ("white", "default"),
-            "dunder": ("white", "default"),
             "keyword": ("dark magenta", "default"),
-            "exception": ("white", "default"),
-
             "name": ("white", "default"),
             "literal": ("dark cyan", "default"),
             "string": ("dark red", "default"),
@@ -489,7 +480,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
 
         # }}}
     elif theme == "solarized":
-        # {{{ solarized
+    # {{{ solarized
         palette_dict.update({
             # UI
             "header": ("black", "light blue", "standout"),
@@ -560,17 +551,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "highlighted source": ("light blue", "black"),
 
             "line number": ("light blue", "default"),
-            "keyword2": ("dark green", "default"),
-
-            "namespace": ("dark green", "default"),
-            "operator": ("light blue", "default"),
-            "argument": ("light blue", "default"),
-            "builtin": ("dark green", "default"),
-            "pseudo": ("light blue", "default"),
-            "dunder": ("light blue", "default"),
             "keyword": ("dark green", "default"),
-            "exception": ("light blue", "default"),
-
             "name": ("light blue", "default"),
             "literal": ("dark cyan", "default"),
             "string": ("dark cyan", "default"),
@@ -600,9 +581,9 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "command line focused button": ("black", "light blue"),
         })
 
-        # }}}
+    # }}}
     elif theme == "agr-256":
-        # {{{ agr-256
+    # {{{ agr-256
         palette_dict.update({
             "header": ("h235", "h252", "standout"),
 
@@ -699,24 +680,15 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "current highlighted source": ("h255", "h22"),
 
             "line number": ("h241", "h235"),
-            "keyword2": ("h111", "h235"),
-            "name": ("h192", "h235"),
-            "literal": ("h173", "h235"),
-
-            "namespace": ("h111", "h235"),
-            "operator": ("h255", "h235"),
-            "argument": ("h255", "h235"),
-            "builtin": ("h255", "h235"),
-            "pseudo": ("h255", "h235"),
-            "dunder": ("h192", "h235"),
             "keyword": ("h111", "h235"),
-            "exception": ("h255", "h235"),
 
+            "literal": ("h173", "h235"),
             "string": ("h113", "h235"),
             "doublestring": ("h113", "h235"),
             "singlestring": ("h113", "h235"),
             "docstring": ("h113", "h235"),
 
+            "name": ("h192", "h235"),
             "punctuation": ("h223", "h235"),
             "comment": ("h246", "h235"),
 
@@ -740,160 +712,98 @@ def get_palette(may_use_fancy_formats, theme="classic"):
         })
         # }}}
     elif theme == "monokai":
-        # {{{ monokai
+        # {{{ midnight
+
+        # Based on XCode's midnight theme
+        # Looks best in a console with green text against black background
         palette_dict.update({
-            "header": ("black", "light gray", "standout"),
+            "variables": ("white", "default"),
 
-            # {{{ variables view
-            "variables": ("black", "dark gray"),
-            "variable separator": ("dark cyan", "light gray"),
+            "var label": ("light blue", "default"),
+            "var value": ("white", "default"),
 
-            "var label": ("light gray", "dark gray"),
-            "var value": ("white", "dark gray"),
-            "focused var label": ("light gray", "light blue"),
-            "focused var value": ("white", "light blue"),
+            "stack": ("white", "default"),
 
-            "highlighted var label": ("light gray", "dark green"),
-            "highlighted var value": ("white", "dark green"),
-            "focused highlighted var label": ("light gray", "light blue"),
-            "focused highlighted var value": ("white", "light blue"),
+            "frame name": ("white", "default"),
+            "frame class": ("dark blue", "default"),
+            "frame location": ("light cyan", "default"),
 
-            "return label": ("light gray", "dark gray"),
-            "return value": ("light cyan", "dark gray"),
-            "focused return label": ("yellow", "light blue"),
-            "focused return value": ("white", "light blue"),
+            "current frame name": (add_setting("white", "bold"), "default"),
+            "current frame class": ("dark blue", "default"),
+            "current frame location": ("light cyan", "default"),
 
-            # }}}
+            "focused frame name": ("black", "dark green"),
+            "focused frame class": (add_setting("white", "bold"), "dark green"),
+            "focused frame location": ("dark blue", "dark green"),
 
-            # {{{ stack view
+            "focused current frame name": ("black", "dark green"),
+            "focused current frame class": (add_setting("white", "bold"), "dark green"),
+            "focused current frame location": ("dark blue", "dark green"),
 
-            "stack": ("black", "dark gray"),
+            "breakpoint": ("default", "default"),
 
-            "frame name": ("light gray", "dark gray"),
-            "focused frame name": ("light gray", "light blue"),
-            "frame class": ("dark blue", "dark gray"),
-            "focused frame class": ("dark blue", "light blue"),
-            "frame location": ("white", "dark gray"),
-            "focused frame location": ("white", "light blue"),
+            "search box": ("default", "default"),
 
-            "current frame name": (add_setting("white", "bold"),
-                "dark gray"),
-            "focused current frame name": (add_setting("white", "bold"),
-                "light blue", "bold"),
-            "current frame class": ("dark blue", "dark gray"),
-            "focused current frame class": ("dark blue", "dark green"),
-            "current frame location": ("light cyan", "dark gray"),
-            "focused current frame location": ("light cyan", "light blue"),
+            "breakpoint": ("white", "default"),
+            "disabled breakpoint": ("dark gray", "default"),
+            "focused breakpoint": ("black", "dark green"),
+            "focused disabled breakpoint": ("dark gray", "dark green"),
+            "current breakpoint": (add_setting("white", "bold"), "default"),
+            "disabled current breakpoint": (add_setting("dark gray", "bold"), "default"),
+            "focused current breakpoint": (add_setting("white", "bold"), "dark green", "bold"),
+            "focused disabled current breakpoint": (add_setting("dark gray", "bold"), "dark green", "bold"),
 
-            # }}}
-
-            # {{{ breakpoint view
-
-            "breakpoint": ("light gray", "dark gray"),
-            "disabled breakpoint": ("black", "dark gray"),
-            "focused breakpoint": ("light gray", "light blue"),
-            "focused disabled breakpoint": ("black", "light blue"),
-            "current breakpoint": (add_setting("white", "bold"), "dark gray"),
-            "disabled current breakpoint": ("black", "dark gray"),
-            "focused current breakpoint":
-                (add_setting("white", "bold"), "light blue"),
-            "focused disabled current breakpoint":
-                ("black", "light blue"),
-
-            # }}}
-
-            # {{{ ui widgets
-
-            "selectable": ("light gray", "dark gray"),
-            "focused selectable": ("white", "light blue"),
-
-            "button": ("light gray", "dark gray"),
-            "focused button": ("white", "light blue"),
-
-            "background": ("black", "light gray"),
-            "hotkey": (add_setting("black", "underline"), "light gray", "underline"),
-            "focused sidebar": ("light blue", "light gray", "standout"),
-
-            "warning": (add_setting("white", "bold"), "dark red", "standout"),
-
-            "label": ("black", "light gray"),
-            "value": ("white", "dark gray"),
-            "fixed value": ("light gray", "dark gray"),
-
-            "search box": ("white", "dark gray"),
-            "search not found": ("white", "dark red"),
-
-            "dialog title": (add_setting("white", "bold"), "dark gray"),
-
-            # }}}
-
-            # {{{ source view
-
-            "breakpoint marker": ("dark red", "black"),
-
-            "breakpoint source": ("light gray", "dark red"),
-            "breakpoint focused source": ("black", "dark red"),
-            "current breakpoint source": ("black", "dark red"),
-            "current breakpoint focused source": ("white", "dark red"),
-
-            # }}}
-
-            # {{{ highlighting
-
-            "source": ("white", "black"),
-            "focused source": ("white", "light blue"),
-            "highlighted source": ("black", "dark magenta"),
-            "current source": ("black", "light gray"),
-            "current focused source": ("white", "dark cyan"),
-            "current highlighted source": ("white", "dark cyan"),
+            "source": ("white", "default"),
+            "highlighted source": ("white", "light cyan"),
+            "current source": ("white", "light gray"),
+            "current focused source": ("white", "brown"),
 
             "line number": ("dark gray", "black"),
             "keyword2": ("light cyan", "black"),
             "name": ("light green", "black"),
             "literal": ("light magenta", "black"),
-            
+
             "namespace": ("light red", "black"),
             "operator": ("light red", "black"),
             "argument": ("brown", "black"),
             "builtin": ("light cyan", "black"),
             "pseudo": ("light magenta", "black"),
             "dunder": ("light cyan", "black"),
-            "keyword": ("light red", "black"),
             "exception": ("light cyan", "black"),
+            "keyword": ("light red", "black"),
 
-            "string": ("yellow", "black"),
-            "doublestring": ("yellow", "black"),
-            "singlestring": ("yellow", "black"),
-            "docstring": ("light gray", "black"),
+            "string": ("dark red", "default"),
+            "doublestring": ("dark red", "default"),
+            "singlestring": ("light blue", "default"),
+            "docstring": ("light red", "default"),
+            "backtick": ("light green", "default"),
+            "punctuation": ("white", "default"),
+            "comment": ("dark green", "default"),
+            "classname": ("dark cyan", "default"),
+            "funcname": ("white", "default"),
 
-            "punctuation": ("white", "black"),
-            "comment": ("light gray", "black"),
-
-            # }}}
+            "breakpoint marker": ("dark red", "default"),
 
             # {{{ shell
 
-            "command line edit":
-            ("white", "black"),
-            "command line prompt":
-            (add_setting("yellow", "bold"), "black"),
+            "command line edit": ("white", "default"),
+            "command line prompt": (add_setting("white", "bold"), "default"),
 
-            "command line output":
-            (add_setting("yellow", "bold"), "black"),
-            "command line input":
-            ("white", "black"),
-            "command line error":
-            (add_setting("light red", "bold"), "black"),
+            "command line output": (add_setting("white", "bold"), "default"),
+            "command line input": (add_setting("white", "bold"), "default"),
+            "command line error": (add_setting("light red", "bold"), "default"),
 
-            "focused command line output":
-            ("black", "light blue"),
-            "focused command line input":
-            (add_setting("light cyan", "bold"), "light blue"),
-            "focused command line error":
-            ("black", "light blue"),
+            "focused command line output": ("black", "dark green"),
+            "focused command line input": (add_setting("white", "bold"), "dark green"),
+            "focused command line error": ("black", "dark green"),
+
+            "command line clear button": (add_setting("white", "bold"), "default"),
+            "command line focused button": ("black", "light gray"), # White
+            # doesn't work in curses mode
 
             # }}}
-            })
+
+        })
 
         # }}}
     elif theme == "monokai-256":
@@ -1004,8 +914,8 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "builtin": ("h51", "h235"),
             "pseudo": ("h141", "h235"),
             "dunder": ("h51", "h235"),
-            "keyword": ("h198", "h235"),
             "exception": ("h51", "h235"),
+            "keyword": ("h198", "h235"),
 
             "string": ("h228", "h235"),
             "doublestring": ("h228", "h235"),
@@ -1049,6 +959,11 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             from traceback import print_exc
             print_exc()
             raw_input("Hit enter:")
+
+    # Apply style inheritance
+    for child, parent in inheritance_map:
+        if palette_dict[child] is None:
+            palette_dict[child] = palette_dict[parent] 
 
     palette_list = []
     for setting_name, color_values in palette_dict.items():


### PR DESCRIPTION
This change adds "monokai" and "monokai-256" to the built-in Themes. It faithfully reproduces all Monokai styling except for coloring optional argument names orange in function calls (implementing that would have required a two-pass parser to go backwards and change the token type of the argument name after encountering the "=" which follows it.)

This implementation adds several new palette items: "namespace", "operator", "argument", "builtin", "pseudo", "dunder", "exception", and "keyword2".  Their meaning is documented near the top of theme.py

All legacy Themes have been updated to assign colors to the new palette items such that the legacy themes appear identical before and after this change.  The addition of the new palette items makes it possible, if you like, to expand the colorization of the legacy themes in the future. I thought it was cleanest for me to keep this pull request focussed on the new theme and not muddy the waters by making any changes to the appearance of the legacy ones.

I have tested on Python 3.5 and 2.7, and raw/curses (though both appear identical on my platform).

**monokai-256 vs Sublime**
<img width="941" alt="monokai-256" src="https://cloud.githubusercontent.com/assets/136718/21089341/23d53790-bfec-11e6-985b-97d5b4691238.png">

**monokai vs Sublime**
<img width="921" alt="monokai" src="https://cloud.githubusercontent.com/assets/136718/21089343/29260ddc-bfec-11e6-8452-2153948ddd41.png">

**Legacy themes with Monokai build (left) and trunk build (right)**
<img width="1439" alt="classic_compare" src="https://cloud.githubusercontent.com/assets/136718/21089359/43dcf078-bfec-11e6-9580-dc2ab6205552.png">

<img width="1435" alt="vim_compare" src="https://cloud.githubusercontent.com/assets/136718/21089365/574e5c78-bfec-11e6-808c-21aabf266ac4.png">

<img width="1437" alt="dark_vim_compare" src="https://cloud.githubusercontent.com/assets/136718/21089370/6879634e-bfec-11e6-8a27-555e23be0401.png">

<img width="1439" alt="midnight_compare" src="https://cloud.githubusercontent.com/assets/136718/21089381/7b30e14c-bfec-11e6-91b8-c52611a17223.png">

<img width="1437" alt="solarized_compare" src="https://cloud.githubusercontent.com/assets/136718/21089396/926bfc52-bfec-11e6-8704-b9da78212ecb.png">

<img width="1436" alt="agr-256_compare" src="https://cloud.githubusercontent.com/assets/136718/21089412/b3d8873e-bfec-11e6-8c4d-8df3505044d5.png">

