### PR TITLE
Add set_continue() function to __init__.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,24 +118,25 @@ PuDB also has a `mailing list <http://lists.tiker.net/listinfo/pudb>`_ that
 you may use to submit patches and requests for help.  You can also send a pull
 request to the `GitHub repository <https://github.com/inducer/pudb>`_
 
-Attaching to Running Code
--------------------------
+Starting the debugger without breaking
+--------------------------------------
 
-An alternative to using ``set_trace`` is to use::
+To start the debugger without actually pausing use::
 
-    from pudb import activate_and_continue; activate_and_continue()
+    from pudb import set_trace; set_trace(paused=False)
 
 at the top of your code.  This will start the debugger without breaking, and
-run it until a predefined breakpoint is hit.
+run it until a predefined breakpoint is hit. You can also press ``b`` on a
+``set_trace`` call inside the debugger, and it will prevent it from stopping
+there.
 
 Interrupt Handlers
 ------------------
 
-Both ``set_trace`` and ``activate_and_continue`` set ``SIGINT`` (i.e.,
-``Ctrl-c``) to run ``set_trace``, so that typing ``Ctrl-c`` while your code is
-running will break the code and start debugging. See the docstring of
-``set_interrupt_handler`` for more information. Note that this only works in
-the main thread.
+``set_trace`` sets ``SIGINT`` (i.e., ``Ctrl-c``) to run ``set_trace``, so that
+typing ``Ctrl-c`` while your code is running will break the code and start
+debugging. See the docstring of ``set_interrupt_handler`` for more
+information. Note that this only works in the main thread.
 
 Programming PuDB
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -123,12 +123,19 @@ Attaching to Running Code
 
 An alternative to using ``set_trace`` is to use::
 
-    from pudb import set_interrupt_handler; set_interrupt_handler()
+    from pudb import activate_and_continue; activate_and_continue()
 
-at the top of your code.  This will set ``SIGINT`` (i.e., ``Ctrl-c``) to
-run ``set_trace``, so that typing ``Ctrl-c`` while your code is running
-will break the code and start debugging.  See the docstring of
-``set_interrupt_handler`` for more information.
+at the top of your code.  This will start the debugger without breaking, and
+run it until a predefined breakpoint is hit.
+
+Interrupt Handlers
+------------------
+
+Both ``set_trace`` and ``activate_and_continue`` set ``SIGINT`` (i.e.,
+``Ctrl-c``) to run ``set_trace``, so that typing ``Ctrl-c`` while your code is
+running will break the code and start debugging. See the docstring of
+``set_interrupt_handler`` for more information. Note that this only works in
+the main thread.
 
 Programming PuDB
 ----------------

--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -24,7 +24,7 @@ class PudbShortcuts(object):
 
 
     @property
-    def cont(self):
+    def go(self):
         import sys
         dbg = _get_debugger()
 

--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -160,7 +160,7 @@ def set_trace():
         set_interrupt_handler()
     dbg.set_trace(sys._getframe().f_back)
 
-def set_continue():
+def activate_and_continue():
     """
     Acts like a set_trace() immediately followed by a 'c' (continue).
 

--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -178,6 +178,8 @@ def set_trace(paused=True):
 
     dbg.set_trace(sys._getframe().f_back, paused=paused)
 
+start = set_trace
+
 def _interrupt_handler(signum, frame):
     from pudb import _get_debugger
     _get_debugger().set_trace(frame, as_breakpoint=False)

--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -22,24 +22,16 @@ class PudbShortcuts(object):
             set_interrupt_handler()
         dbg.set_trace(sys._getframe().f_back)
 
+
     @property
     def cont(self):
         import sys
         dbg = _get_debugger()
 
-        frame = sys._getframe().f_back
-
-        while frame:
-            frame.f_trace = dbg.trace_dispatch
-            dbg.botframe = frame
-            frame = frame.f_back
-
         import threading
         if isinstance(threading.current_thread(), threading._MainThread):
             set_interrupt_handler()
-
-        dbg.set_continue()
-        sys.settrace(dbg.trace_dispatch)
+        dbg.set_trace(sys._getframe().f_back, paused=False)
 
 
 if PY3:
@@ -170,37 +162,21 @@ def runcall(*args, **kwds):
     return _get_debugger().runcall(*args, **kwds)
 
 
-def set_trace():
+def set_trace(paused=True):
+    """
+    Start the debugger
+
+    If paused=False (the default is True), the debugger will not stop here
+    (same as immediately pressing 'c' to continue).
+    """
     import sys
     dbg = _get_debugger()
 
     import threading
     if isinstance(threading.current_thread(), threading._MainThread):
         set_interrupt_handler()
-    dbg.set_trace(sys._getframe().f_back)
 
-def activate_and_continue():
-    """
-    Acts like a set_trace() immediately followed by a 'c' (continue).
-
-    In other words, it only stops on a previously defined breakpoint.
-    """
-    import sys
-    dbg = _get_debugger()
-
-    frame = sys._getframe().f_back
-
-    while frame:
-        frame.f_trace = dbg.trace_dispatch
-        dbg.botframe = frame
-        frame = frame.f_back
-
-    import threading
-    if isinstance(threading.current_thread(), threading._MainThread):
-        set_interrupt_handler()
-
-    dbg.set_continue()
-    sys.settrace(dbg.trace_dispatch)
+    dbg.set_trace(sys._getframe().f_back, paused=paused)
 
 def _interrupt_handler(signum, frame):
     from pudb import _get_debugger

--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -160,6 +160,28 @@ def set_trace():
         set_interrupt_handler()
     dbg.set_trace(sys._getframe().f_back)
 
+def set_continue():
+    """
+    Acts like a set_trace() immediately followed by a 'c' (continue).
+
+    In other words, it only stops on a previously defined breakpoint.
+    """
+    import sys
+    dbg = _get_debugger()
+
+    frame = sys._getframe().f_back
+
+    while frame:
+        frame.f_trace = dbg.trace_dispatch
+        dbg.botframe = frame
+        frame = frame.f_back
+
+    import threading
+    if isinstance(threading.current_thread(), threading._MainThread):
+        set_interrupt_handler()
+
+    dbg.set_continue()
+    sys.settrace(dbg.trace_dispatch)
 
 def _interrupt_handler(signum, frame):
     from pudb import _get_debugger

--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -22,6 +22,25 @@ class PudbShortcuts(object):
             set_interrupt_handler()
         dbg.set_trace(sys._getframe().f_back)
 
+    @property
+    def cont(self):
+        import sys
+        dbg = _get_debugger()
+
+        frame = sys._getframe().f_back
+
+        while frame:
+            frame.f_trace = dbg.trace_dispatch
+            dbg.botframe = frame
+            frame = frame.f_back
+
+        import threading
+        if isinstance(threading.current_thread(), threading._MainThread):
+            set_interrupt_handler()
+
+        dbg.set_continue()
+        sys.settrace(dbg.trace_dispatch)
+
 
 if PY3:
     import builtins

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -194,7 +194,7 @@ class Debugger(bdb.Bdb):
                     break
                 frame = frame.f_back
 
-    def set_trace(self, frame=None, as_breakpoint=True):
+    def set_trace(self, frame=None, as_breakpoint=None, paused=True):
         """Start debugging from `frame`.
 
         If frame is not specified, debugging starts from caller's frame.
@@ -202,7 +202,19 @@ class Debugger(bdb.Bdb):
         Unlike Bdb.set_trace(), this does not call self.reset(), which causes
         the debugger to enter bdb source code. This also implements treating
         set_trace() calls as breakpoints in the PuDB UI.
+
+        If as_breakpoint=True (the default), this call will be treated like a
+        breakpoint in the UI (you can press 'b' on it to disable breaking
+        here).
+
+        If paused=False, the debugger will not break here.
         """
+        if as_breakpoint is None:
+            if not paused:
+                as_breakpoint = False
+            else:
+                as_breakpoint = True
+
         if frame is None:
             frame = thisframe = sys._getframe().f_back
         else:
@@ -225,7 +237,10 @@ class Debugger(bdb.Bdb):
                     self.ui.set_source_code_provider(
                             self.ui.source_code_provider, force_update=True)
 
-            self.set_step()
+            if paused:
+                self.set_step()
+            else:
+                self.set_continue()
             sys.settrace(self.trace_dispatch)
         else:
             return


### PR DESCRIPTION
This lets you start the debugger and immediately continue, i.e., it only stops
on a previously defined breakpoint.

Fixes #234.

Let me know if you would prefer a better name, or just a flag to set_trace(). 