### PR TITLE
Don't use SetPropagatingDict in the built in console

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1554,8 +1554,10 @@ class DebuggerUI(FrameVarInfoKeeper):
             sys.stdin = None
             sys.stderr = sys.stdout = StringIO()
             try:
+                # Don't use cmdline_get_namespace() here, it breaks things in
+                # Python 2 (issue #166).
                 eval(compile(cmd, "<pudb command line>", 'single'),
-                        cmdline_get_namespace())
+                        self.debugger.curframe.f_globals, self.debugger.curframe.f_locals)
             except:
                 tp, val, tb = sys.exc_info()
 

--- a/pudb/shell.py
+++ b/pudb/shell.py
@@ -30,6 +30,20 @@ except ImportError:
 # {{{ combined locals/globals dict
 
 class SetPropagatingDict(dict):
+    """
+    Combine dict into one, with assignments affecting a target dict
+
+    The source dicts are combined so that early dicts in the list have higher
+    precedence.
+
+    Typical usage is SetPropagatingDict([locals, globals], locals). This is
+    used for functions like rlcompleter.Completer and code.InteractiveConsole,
+    which only take a single dictionary. This way, changes made to it are
+    propagated to locals. Note that assigning to locals only actually works
+    at the module level, when locals() is the same as globals(), so
+    propagation doesn't happen at all if the debugger is inside a function
+    frame.
+    """
     def __init__(self, source_dicts, target_dict):
         dict.__init__(self)
         for s in source_dicts[::-1]:


### PR DESCRIPTION
Passing a dict subclass to eval is not supported in Python 2. This was causing
weird issues where the C-x would break the UI (I am not clear exactly how it
caused those issues).

The point of SetPropagatingDict is to combine globals and locals into a single
dictionary for things like code.InteractiveConsole and rlcompleter.Completer,
which take a single dictionary, but to allow changes to propagate, so that
assignments in the shell can modify global names. However, this is completely
unnecessary for the built in shell, as we call eval() ourselves, so we can
just pass the exact globals and locals dicts separately.

This fixes #166.