### PR TITLE
Added TravisCI and codecov.io support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,25 @@
+[run]
+branch = True
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+ignore_errors = True
+
+[html]
+directory = coverage_html_report

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ traceback*txt
 .DS_Store
 .cache/
 .coverage
+coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.5"
+  - "3.6"
+
+# command to install dependencies
+install: "pip install -r requirements.dev.txt"
+
+# command to run tests
+script: pytest --cov=pudb test
+
+after_success:
+  - upload_coverage.sh
+
+sudo: false

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+.. image:: https://travis-ci.org/inducer/pudb.svg?branch=master
+  :target: https://travis-ci.org/inducer/pudb
+
+.. image:: https://codecov.io/gh/inducer/pudb/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/inducer/pudb
+
 PuDB is a full-screen, console-based visual debugger for Python.
 
 Its goal is to provide all the niceties of modern GUI-based debuggers in a

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,4 @@
+codecov==2.0.5
 coverage==4.3.4
 pbr==2.0.0
 py==1.4.33
@@ -5,5 +6,6 @@ Pygments==2.2.0
 pytest==3.0.7
 pytest-cov==2.4.0
 pytest-mock==1.6.0
+requests==2.13.0
 six==1.10.0
 urwid==1.3.1

--- a/upload_coverage.sh
+++ b/upload_coverage.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ -z "$COVERAGE" ]; then
+	echo "coverage is not selected for this build"
+	exit 0
+fi
+
+echo "uploading coverage"
+
+eval "codecov --token=$COVERAGE"


### PR DESCRIPTION
1. Register at https://travis-ci.org and here https://codecov.io
2. Syncronize `pudb` repo.
3. In the TravisCI setting set environment variable `COVERAGE` with a value from of the upload token from codecov.io (see pudb settings at codecov.io)
4. The badges ![badges](http://i.prntscr.com/3550f78486ac4add8eb0b05a08ebdb40.png) will be added to readme.rst

An example: https://github.com/discort/pudb