### PR TITLE
Add support for custom shells

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,9 +17,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- General configuration ------------------------------------------------
@@ -177,4 +177,3 @@ texinfo_documents = [
 ]
 
 autoclass_content = "both"
-

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -12,8 +12,8 @@ Table of Contents
 
     starting
     usage
+    shells
     misc
-
 
 
 Indices and Tables

--- a/doc/shells.rst
+++ b/doc/shells.rst
@@ -1,0 +1,56 @@
+Shells
+======
+
+Internal shell
+--------------
+
+At any point while debugging, press ``Ctrl-x`` to switch to the built in
+interactive shell. From here, you can execute Python commands at the current
+point of the debugger. Press ``Ctrl-x`` again to move back to the debugger.
+
+Keyboard shortcuts defined in the internal shell:
+
++--------------------+--------------------+
+|Enter               |Execute the current |
+|                    |command             |
++--------------------+--------------------+
+|Ctrl-v              |Insert a newline    |
+|                    |(for multiline      |
+|                    |commands)           |
++--------------------+--------------------+
+|Ctrl-n/p            |Browse command      |
+|                    |history             |
++--------------------+--------------------+
+|Up/down arrow       |Select history      |
++--------------------+--------------------+
+|TAB                 |Tab completion      |
++--------------------+--------------------+
+|+/-                 |grow/shrink the     |
+|                    |shell (when a       |
+|                    |history item is     |
+|                    |selected)           |
++--------------------+--------------------+
+|_/=                 |minimize/maximize   |
+|                    |the shell (when a   |
+|                    |history item is     |
+|                    |selected)           |
++--------------------+--------------------+
+
+External shells
+---------------
+
+To open the external shell, press the ``!`` key while debugging. Unlike the
+internal shell, external shells close the debugger UI while the shell is
+active. Press ``Ctrl-d`` at any time to exit the shell and return to the
+debugger.
+
+To configure the shell used by PuDB, open the settings (``Ctrl-p``) and select
+the shell.
+
+PuDB supports the following external shells.
+
+- Internal (same as pressing ``Ctrl-x``). This is the default.
+- Classic (similar to the default ``python`` interactive shell)
+- `IPython <https://ipython.org/>`_
+- `bpython <https://bpython-interpreter.org/>`_
+- `ptpython <https://github.com/jonathanslenders/ptpython>`_

--- a/doc/shells.rst
+++ b/doc/shells.rst
@@ -54,3 +54,28 @@ PuDB supports the following external shells.
 - `IPython <https://ipython.org/>`_
 - `bpython <https://bpython-interpreter.org/>`_
 - `ptpython <https://github.com/jonathanslenders/ptpython>`_
+
+Custom shells
+-------------
+
+To define a custom external shell, create a file with a function
+``pudb_shell(_globals, _locals, first_time)`` at the module level. Then, in
+the settings (``Ctrl-p``), select "Custom" under the shell settings, and add
+the path to the file.
+
+Here is an example custom shell file:
+
+.. literalinclude:: ../example-shell.py
+   :language: python
+
+Note, many shells do not allow passing in globals and locals dictionaries
+separately. In this case, you can merge the two with
+
+.. code-block:: python
+
+   from pudb.shell import SetPropagatingDict
+   ns = SetPropagatingDict([_locals, _globals], _locals)
+
+Here is more information on ``SetPropagatingDict``:
+
+.. autoclass:: pudb.shell.SetPropagatingDict

--- a/doc/shells.rst
+++ b/doc/shells.rst
@@ -59,7 +59,7 @@ Custom shells
 -------------
 
 To define a custom external shell, create a file with a function
-``pudb_shell(_globals, _locals, first_time)`` at the module level. Then, in
+``pudb_shell(_globals, _locals)`` at the module level. Then, in
 the settings (``Ctrl-p``), select "Custom" under the shell settings, and add
 the path to the file.
 

--- a/example-shell.py
+++ b/example-shell.py
@@ -46,3 +46,4 @@ def pudb_shell(_globals, _locals):
     from code import InteractiveConsole
     cons = InteractiveConsole(ns)
     cons.interact("Press Ctrl-D to return to the debugger")
+    # When the function returns, control will be returned to the debugger.

--- a/example-shell.py
+++ b/example-shell.py
@@ -4,7 +4,7 @@ shell used when pressing the ! key in the debugger (it does not affect the
 Ctrl-x shell that is built into PuDB).
 
 To create a custom shell, create a file like this one with a function called
-pudb_shell(_globals, _locals, first_time) defined at the module level. Note
+pudb_shell(_globals, _locals) defined at the module level. Note
 that the file will be execfile'd.
 
 Then, go to the PuDB preferences window (type Ctrl-p inside of PuDB) and add
@@ -15,18 +15,12 @@ The example in this file
 """
 
 # Define this a function with this name and signature at the module level.
-def pudb_shell(_globals, _locals, first_time):
+def pudb_shell(_globals, _locals):
     """
     This example shell runs a classic Python shell. It is based on
     run_classic_shell in pudb.shell.
 
     """
-    # first_time is True the first time ! is pressed, and False otherwise
-    if first_time:
-        banner = "This is the example shell. Hit Ctrl-D to return to PuDB."
-    else:
-        banner = ""
-
     # Many shells only let you pass in a single locals dictionary, rather than
     # separate globals and locals dictionaries. In this case, you can use
     # pudb.shell.SetPropagatingDict to automatically merge the two into a
@@ -51,5 +45,4 @@ def pudb_shell(_globals, _locals, first_time):
 
     from code import InteractiveConsole
     cons = InteractiveConsole(ns)
-
-    cons.interact(banner)
+    cons.interact("Press Ctrl-D to return to the debugger")

--- a/example-shell.py
+++ b/example-shell.py
@@ -1,0 +1,55 @@
+"""
+This file shows how you can define a custom shell for PuDB. This is the
+shell used when pressing the ! key in the debugger (it does not affect the
+Ctrl-x shell that is built into PuDB).
+
+To create a custom shell, create a file like this one with a function called
+pudb_shell(_globals, _locals, first_time) defined at the module level. Note
+that the file will be execfile'd.
+
+Then, go to the PuDB preferences window (type Ctrl-p inside of PuDB) and add
+the path to the file in the "Custom" field under the "Shell" heading.
+
+The example in this file
+
+"""
+
+# Define this a function with this name and signature at the module level.
+def pudb_shell(_globals, _locals, first_time):
+    """
+    This example shell runs a classic Python shell. It is based on
+    run_classic_shell in pudb.shell.
+
+    """
+    # first_time is True the first time ! is pressed, and False otherwise
+    if first_time:
+        banner = "This is the example shell. Hit Ctrl-D to return to PuDB."
+    else:
+        banner = ""
+
+    # Many shells only let you pass in a single locals dictionary, rather than
+    # separate globals and locals dictionaries. In this case, you can use
+    # pudb.shell.SetPropagatingDict to automatically merge the two into a
+    # single dictionary. It does this in such a way that assignments propogate
+    # to _locals, so that when the debugger is at the module level, variables
+    # can be reassigned in the shell.
+    from pudb.shell import SetPropagatingDict
+    ns = SetPropagatingDict([_locals, _globals], _locals)
+
+    try:
+        import readline
+        import rlcompleter
+        HAVE_READLINE = True
+    except ImportError:
+        HAVE_READLINE = False
+
+    if HAVE_READLINE:
+        readline.set_completer(
+                rlcompleter.Completer(ns).complete)
+        readline.parse_and_bind("tab: complete")
+        readline.clear_history()
+
+    from code import InteractiveConsole
+    cons = InteractiveConsole(ns)
+
+    cons.interact(banner)

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -77,12 +77,12 @@ Keys:
 
     Ctrl-l - redraw screen
 
-Command line-related:
-    ! - invoke configured python command line in current environment
-    Ctrl-x - toggle inline command line focus
+Shell-related:
+    ! - open the external shell (configured in the settings)
+    Ctrl-x - toggle the internal shell focus
 
-    +/- - grow/shrink inline command line (active in command line history)
-    _/= - minimize/maximize inline command line (active in command line history)
+    +/- - grow/shrink inline shell (active in command line history)
+    _/= - minimize/maximize inline shell (active in command line history)
 
     Ctrl-v - insert newline
     Ctrl-n/p - browse command line history

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1799,12 +1799,6 @@ class DebuggerUI(FrameVarInfoKeeper):
         def run_external_cmdline(w, size, key):
             self.screen.stop()
 
-            if not hasattr(self, "have_been_to_cmdline"):
-                self.have_been_to_cmdline = True
-                first_cmdline_run = True
-            else:
-                first_cmdline_run = False
-
             curframe = self.debugger.curframe
 
             import pudb.shell as shell
@@ -1836,8 +1830,7 @@ class DebuggerUI(FrameVarInfoKeeper):
                     else:
                         runner = shell.custom_shell_dict['pudb_shell']
 
-            runner(curframe.f_locals, curframe.f_globals,
-                    first_cmdline_run)
+            runner(curframe.f_globals, curframe.f_locals)
 
             self.screen.start()
 

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -229,7 +229,7 @@ def edit_config(ui, conf_dict):
                     "in the pudb distribution. Enter the full path to a "
                     "file like it in the box above. '~' will be expanded "
                     "to your home directory. The file should contain a "
-                    "function called pudb_shell(_globals, _locals, first_time) "
+                    "function called pudb_shell(_globals, _locals) "
                     "at the module level. See the PuDB documentation for "
                     "more information."),
             ]

--- a/pudb/shell.py
+++ b/pudb/shell.py
@@ -64,9 +64,10 @@ class SetPropagatingDict(dict):
 
 custom_shell_dict = {}
 
-def run_classic_shell(locals, globals, first_time):
+def run_classic_shell(globals, locals, first_time=[True]):
     if first_time:
         banner = "Hit Ctrl-D to return to PuDB."
+        first_time.pop()
     else:
         banner = ""
 
@@ -97,7 +98,7 @@ def run_classic_shell(locals, globals, first_time):
         readline.write_history_file(hist_file)
 
 
-def run_bpython_shell(locals, globals, first_time):
+def run_bpython_shell(globals, locals):
     ns = SetPropagatingDict([locals, globals], locals)
 
     import bpython.cli
@@ -135,10 +136,11 @@ def ipython_version():
         return None
 
 
-def run_ipython_shell_v10(locals, globals, first_time):
+def run_ipython_shell_v10(globals, locals, first_time=[True]):
     '''IPython shell from IPython version 0.10'''
     if first_time:
         banner = "Hit Ctrl-D to return to PuDB."
+        first_time.pop()
     else:
         banner = ""
 
@@ -150,7 +152,7 @@ def run_ipython_shell_v10(locals, globals, first_time):
             .mainloop(banner=banner)
 
 
-def _update_ipython_ns(shell, locals, globals):
+def _update_ipython_ns(shell, globals, locals):
     '''Update the IPython 0.11 namespace at every visit'''
 
     shell.user_ns = locals.copy()
@@ -170,10 +172,11 @@ def _update_ipython_ns(shell, locals, globals):
     shell.init_completer()
 
 
-def run_ipython_shell_v11(locals, globals, first_time):
+def run_ipython_shell_v11(globals, locals, first_time=[True]):
     '''IPython shell from IPython version 0.11'''
     if first_time:
         banner = "Hit Ctrl-D to return to PuDB."
+        first_time.pop()
     else:
         banner = ""
 
@@ -200,7 +203,7 @@ def run_ipython_shell_v11(locals, globals, first_time):
     old_globals = shell.user_global_ns
 
     # Update shell with current namespace
-    _update_ipython_ns(shell, locals, globals)
+    _update_ipython_ns(shell, globals, locals)
 
     args = []
     if ipython_version() < (5, 0, 0):
@@ -210,20 +213,20 @@ def run_ipython_shell_v11(locals, globals, first_time):
     shell.mainloop(*args)
 
     # Restore originating namespace
-    _update_ipython_ns(shell, old_locals, old_globals)
+    _update_ipython_ns(shell, old_globals, old_locals)
 
 
-def run_ipython_shell(locals, globals, first_time):
+def run_ipython_shell(globals, locals):
     import IPython
     if have_ipython() and hasattr(IPython, 'Shell'):
-        return run_ipython_shell_v10(locals, globals, first_time)
+        return run_ipython_shell_v10(globals, locals)
     else:
-        return run_ipython_shell_v11(locals, globals, first_time)
+        return run_ipython_shell_v11(globals, locals)
 
 # }}}
 
 
-def run_ptpython_shell(locals, globals, first_time):
+def run_ptpython_shell(globals, locals):
     # Use the default ptpython history
     import os
     history_filename = os.path.expanduser('~/.ptpython_history')

--- a/pudb/shell.py
+++ b/pudb/shell.py
@@ -36,13 +36,14 @@ class SetPropagatingDict(dict):
     The source dicts are combined so that early dicts in the list have higher
     precedence.
 
-    Typical usage is SetPropagatingDict([locals, globals], locals). This is
-    used for functions like rlcompleter.Completer and code.InteractiveConsole,
-    which only take a single dictionary. This way, changes made to it are
-    propagated to locals. Note that assigning to locals only actually works
-    at the module level, when locals() is the same as globals(), so
-    propagation doesn't happen at all if the debugger is inside a function
-    frame.
+    Typical usage is ``SetPropagatingDict([locals, globals], locals)``. This
+    is used for functions like ``rlcompleter.Completer`` and
+    ``code.InteractiveConsole``, which only take a single dictionary. This
+    way, changes made to it are propagated to locals. Note that assigning to
+    locals only actually works at the module level, when ``locals()`` is the
+    same as ``globals()``, so propagation doesn't happen at all if the
+    debugger is inside a function frame.
+
     """
     def __init__(self, source_dicts, target_dict):
         dict.__init__(self)
@@ -61,6 +62,7 @@ class SetPropagatingDict(dict):
 
 # }}}
 
+custom_shell_dict = {}
 
 def run_classic_shell(locals, globals, first_time):
     if first_time:


### PR DESCRIPTION
This add support for custom shells, similar to custom stringifiers. 

A custom shell can be defined by creating a file with a function `pudb_shell(_globals, _locals, first_time)` at the module level, and setting it in the settings.

The `first_time` setting is there to match the existing shells, but it seems useless (a function can easily tell if it has already been called), so it should perhaps be removed.

I also added some documentation for shells in general. 