### PR TITLE
Tell ptpython to read/process the user's config file.

### DIFF
--- a/pudb/shell.py
+++ b/pudb/shell.py
@@ -12,7 +12,7 @@ else:
     HAVE_BPYTHON = True
 
 try:
-    from ptpython.repl import embed as ptpython_embed
+    from ptpython.repl import embed as ptpython_embed, run_config
 except ImportError:
     HAVE_PTPYTHON = False
 else:
@@ -233,7 +233,8 @@ def run_ptpython_shell(globals, locals):
     import os
     history_filename = os.path.expanduser('~/.ptpython_history')
     ptpython_embed(globals.copy(), locals.copy(),
-                   history_filename=history_filename)
+                   history_filename=history_filename,
+                   configure=run_config)
 
 
 # vim: foldmethod=marker


### PR DESCRIPTION
Am using ptpython as the embedded shell during a pudb debugging session and noticed that ptpython was not reading my settings stored in ~/.ptpython/conf.py.

Based on the info from https://github.com/django-extensions/django-extensions/pull/716/commits/36fa486d23206a766c3507c36b2bd767e190e98e and https://github.com/django-extensions/django-extensions/issues/711 I was able to update the pudb code to instruct ptpython to read the users config file.

Let me know if you have any questions.

Thanks