### PR TITLE
Use urwid's calc_width in make_canvas

### DIFF
--- a/pudb/ui_tools.py
+++ b/pudb/ui_tools.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 import urwid
-from urwid.util import _target_encoding
+from urwid.util import _target_encoding, calc_width
 
 
 # generic urwid helpers -------------------------------------------------------
@@ -14,7 +14,7 @@ def make_canvas(txt, attr, maxcol, fill_attr=None):
         # filter out zero-length attrs
         line_attr = [(aname, l) for aname, l in line_attr if l > 0]
 
-        diff = maxcol - len(line)
+        diff = maxcol - calc_width(line, 0, len(line))
         if diff > 0:
             line += " "*diff
             line_attr.append((fill_attr, diff))

--- a/test/test_make_canvas.py
+++ b/test/test_make_canvas.py
@@ -49,6 +49,19 @@ def test_byte_boundary():
     )
     assert list(canvas.content()) == [[('var value', None, b'aaaaaa\xc3\xa9')]]
 
+def test_wide_chars():
+    text = u"data: '中文'"
+    canvas = make_canvas(
+        txt=[text],
+        attr=[[('var label', 6), ('var value', 4)]],
+        maxcol=47,
+    )
+    assert list(canvas.content()) == [[
+        ('var label', None, b'data: '),
+        ('var value', None, "'中文'".encode('utf-8')),
+        (None, None, b' '*(47 - 12)), # 10 chars, 2 of which are double width
+        ]]
+
 
 if __name__ == "__main__":
     import sys

--- a/test/test_make_canvas.py
+++ b/test/test_make_canvas.py
@@ -58,7 +58,7 @@ def test_wide_chars():
     )
     assert list(canvas.content()) == [[
         ('var label', None, b'data: '),
-        ('var value', None, "'中文'".encode('utf-8')),
+        ('var value', None, u"'中文'".encode('utf-8')),
         (None, None, b' '*(47 - 12)), # 10 chars, 2 of which are double width
         ]]
 


### PR DESCRIPTION
This does the right thing for double-width and zero-width Unicode characters.

Fixes #232.