### PR TITLE
Don't show "Return: None" when "returning" from a module frame

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -382,6 +382,9 @@ class Debugger(bdb.Bdb):
 
     def user_return(self, frame, return_value):
         """This function is called when a return trap is set here."""
+        if frame.f_code.co_name == '<module>':
+            return
+
         frame.f_locals['__return__'] = return_value
 
         if self._wait_for_mainpyfile:


### PR DESCRIPTION
That is, when the last line of a module file is executed (usually from
runscript).