### PR TITLE
Don't return early when "returning" from a module

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -382,10 +382,8 @@ class Debugger(bdb.Bdb):
 
     def user_return(self, frame, return_value):
         """This function is called when a return trap is set here."""
-        if frame.f_code.co_name == '<module>':
-            return
-
-        frame.f_locals['__return__'] = return_value
+        if frame.f_code.co_name != '<module>':
+            frame.f_locals['__return__'] = return_value
 
         if self._wait_for_mainpyfile:
             if (self.mainpyfile != self.canonic(frame.f_code.co_filename)


### PR DESCRIPTION
We still need to run interaction so that the debugger will show the result of
the last line that was run. We just don't want it to treat the end of the
module as a "return".

For instance, if you have a file with a single variable definition

    a = 1

then if you stop on the definition, pudb will show the variable "a: 1" in the
variables view (but it won't show "return: None" after stepping again).

Fixes https://github.com/inducer/pudb/pull/264#issuecomment-326777042.