### PR TITLE
check 'safely_stringify_for_pudb' on the type #276

### DIFF
--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -232,7 +232,7 @@ def type_stringifier(value):
         except Exception:
             pass
 
-    elif hasattr(value, "safely_stringify_for_pudb"):
+    elif hasattr(type(value), "safely_stringify_for_pudb"):
         try:
             # (E.g.) Mock objects will pretend to have this
             # and return nonsense.


### PR DESCRIPTION
The hasattr call should check for 'safely_stringify_for_pudb' on the type of the object
instead of the object itself, so as not to implicitly call its __getattr__ (if implemented).
This will avoid the exceptions on such magic objects.