### PR TITLE
update Go-to-Line UI with File/Current Line/Go to Line

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1169,7 +1169,7 @@ class DebuggerUI(FrameVarInfoKeeper):
 
             lineno_edit = urwid.IntEdit([
                 ("label", "Go to Line   :")
-                ], '')
+                ], None)
 
             if self.dialog(
                     urwid.ListBox(urwid.SimpleListWalker([

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1168,13 +1168,14 @@ class DebuggerUI(FrameVarInfoKeeper):
             _, line = self.source.get_focus()
 
             lineno_edit = urwid.IntEdit([
-                ("label", "Line number: ")
-                ], line+1)
+                ("label", "Go to Line   :")
+                ], '')
 
             if self.dialog(
                     urwid.ListBox(urwid.SimpleListWalker([
                         labelled_value("File :",
                             self.source_code_provider.identifier()),
+                        labelled_value("Current Line :", line+1),
                         urwid.AttrMap(lineno_edit, "value")
                         ])),
                     [


### PR DESCRIPTION
The proposed PR is a small tweak to the current behavior of the 'Go to Line Number' capability.  Currently, shift-L does three things:  

1. shows the currently loaded file, 
2. shows the line number the cursor is on, and 
3. allows one to enter a new line number to jump to.

A small nuisance is that items 2 and 3 appear together; the current line number appears as a pre-populated entry in the editable field where the user is to enter the desired line number.  This means 
extra typing for the user as the pre-populated line number has to be backspaced over before a new line number can be supplied.

The nuisance becomes pronounced when working with large (ie >1,000 line) Python files as one must hit backspace many times before the line of interest can be given.

The code in the PR merely separates the three features to three lines:  "File" (unmodified from before), "Current Line" which is a non-editable field showing the current line number, and "Go to Line" which is the new, unpopulated urwid.IntEdit() field where one enters the desired line number.
