### PR TITLE
set socket REUSEADDR opt for the remote debugger

### DIFF
--- a/pudb/remote.py
+++ b/pudb/remote.py
@@ -131,6 +131,7 @@ class RemoteDebugger(Debugger):
         this_port = None
         for i in range(search_limit):
             _sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            _sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             this_port = port + i
             try:
                 _sock.bind((host, this_port))


### PR DESCRIPTION
Otherwise sometimes if the remote debugger would use 6900 even after the program is restarted.