### PR TITLE
Show length of array types in var view

### DIFF
--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -238,6 +238,9 @@ def type_stringifier(value):
         except Exception:
             pass
 
+    elif type(value) in [set, frozenset, list, tuple, dict]:
+        return "%s (%s)" % (type(value).__name__, len(value))
+
     return type(value).__name__
 
 


### PR DESCRIPTION
The new code shows length of set, frozenset, list, tuple and dict type
varibles in variable view.