### PR TITLE
Show variables that start with an underscore in the var view

### DIFF
--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -553,7 +553,7 @@ def make_var_view(frame_var_info, locals, globals):
                 attr_prefix="return")
 
     for var in vars:
-        if not var[0] in "_.":
+        if not (var.startswith('__') and var.endswith('__')):
             tmv_walker.walk_value("", var, locals[var])
 
     result = tmv_walker.main_widget_list


### PR DESCRIPTION
We still filter things that start and end with `__`, to filter out things like
`__builtins__`, `__file__`, and so on. It also removes the filtering of variables
that start with `.`, which is only possible if something puts that in globals()
manually.

Fixes #292.