### PR TITLE
Add setting to make access level in variables view persistent

### DIFF
--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -106,6 +106,7 @@ def load_config():
     conf_dict.setdefault("custom_shell", "")
 
     conf_dict.setdefault("wrap_variables", True)
+    conf_dict.setdefault("variables_access_level", "public")
 
     conf_dict.setdefault("display", "auto")
 
@@ -171,6 +172,9 @@ def edit_config(ui, conf_dict):
         pudb.var_view.custom_stringifier_dict = {}
         ui.update_var_view()
 
+    def _update_variables_access_level():
+        ui.update_var_view()
+
     def _update_wrap_variables():
         ui.update_var_view()
 
@@ -213,6 +217,13 @@ def edit_config(ui, conf_dict):
 
                 conf_dict.update(stringifier=newvalue)
                 _update_stringifier()
+
+        elif option == "variables_access_level":
+            # only activate if the new state of the radio button is 'on'
+            if new_state:
+                conf_dict.update(variables_access_level=newvalue)
+                _update_variables_access_level()
+
         elif option == "wrap_variables":
             new_conf_dict["wrap_variables"] = not check_box.get_state()
             conf_dict.update(new_conf_dict)
@@ -340,6 +351,25 @@ def edit_config(ui, conf_dict):
 
     # }}}
 
+    # {{{ variables access level
+
+    variables_access_level_opts = ["public", "private", "all"]
+    variables_access_level_rb_group = []
+    variables_access_level_info = urwid.Text("Set the default attribute visibility "
+        "of variables in the variables list.\n"
+        "\nNote that you can change this option on "
+        "a per-variable basis by selecting the "
+        "variable and pressing '*'.")
+    variables_access_level_rbs = [
+            urwid.RadioButton(variables_access_level_rb_group, name,
+                conf_dict["variables_access_level"] == name,
+                on_state_change=_update_config,
+                user_data=("variables_access_level", name))
+            for name in variables_access_level_opts
+            ]
+
+    # }}}
+
     # {{{ wrap variables
 
     cb_wrap_variables = urwid.CheckBox("Wrap variables",
@@ -396,6 +426,10 @@ def edit_config(ui, conf_dict):
             + [urwid.AttrMap(urwid.Text("\nVariable Stringifier:\n"), "group head")]
             + [stringifier_info]
             + stringifier_rbs
+
+            + [urwid.AttrMap(urwid.Text("\nVariables Attribute Visibility:\n"), "group head")]
+            + [variables_access_level_info]
+            + variables_access_level_rbs
 
             + [urwid.AttrMap(urwid.Text("\nWrap Variables:\n"), "group head")]
             + [cb_wrap_variables]

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -106,7 +106,7 @@ def load_config():
     conf_dict.setdefault("custom_shell", "")
 
     conf_dict.setdefault("wrap_variables", True)
-    conf_dict.setdefault("variables_access_level", "public")
+    conf_dict.setdefault("default_variables_access_level", "public")
 
     conf_dict.setdefault("display", "auto")
 
@@ -172,7 +172,7 @@ def edit_config(ui, conf_dict):
         pudb.var_view.custom_stringifier_dict = {}
         ui.update_var_view()
 
-    def _update_variables_access_level():
+    def _update_default_variables_access_level():
         ui.update_var_view()
 
     def _update_wrap_variables():
@@ -218,11 +218,11 @@ def edit_config(ui, conf_dict):
                 conf_dict.update(stringifier=newvalue)
                 _update_stringifier()
 
-        elif option == "variables_access_level":
+        elif option == "default_variables_access_level":
             # only activate if the new state of the radio button is 'on'
             if new_state:
-                conf_dict.update(variables_access_level=newvalue)
-                _update_variables_access_level()
+                conf_dict.update(default_variables_access_level=newvalue)
+                _update_default_variables_access_level()
 
         elif option == "wrap_variables":
             new_conf_dict["wrap_variables"] = not check_box.get_state()
@@ -353,19 +353,19 @@ def edit_config(ui, conf_dict):
 
     # {{{ variables access level
 
-    variables_access_level_opts = ["public", "private", "all"]
-    variables_access_level_rb_group = []
-    variables_access_level_info = urwid.Text("Set the default attribute visibility "
+    default_variables_access_level_opts = ["public", "private", "all"]
+    default_variables_access_level_rb_group = []
+    default_variables_access_level_info = urwid.Text("Set the default attribute visibility "
         "of variables in the variables list.\n"
         "\nNote that you can change this option on "
         "a per-variable basis by selecting the "
         "variable and pressing '*'.")
-    variables_access_level_rbs = [
-            urwid.RadioButton(variables_access_level_rb_group, name,
-                conf_dict["variables_access_level"] == name,
+    default_variables_access_level_rbs = [
+            urwid.RadioButton(default_variables_access_level_rb_group, name,
+                conf_dict["default_variables_access_level"] == name,
                 on_state_change=_update_config,
-                user_data=("variables_access_level", name))
-            for name in variables_access_level_opts
+                user_data=("default_variables_access_level", name))
+            for name in default_variables_access_level_opts
             ]
 
     # }}}
@@ -428,8 +428,8 @@ def edit_config(ui, conf_dict):
             + stringifier_rbs
 
             + [urwid.AttrMap(urwid.Text("\nVariables Attribute Visibility:\n"), "group head")]
-            + [variables_access_level_info]
-            + variables_access_level_rbs
+            + [default_variables_access_level_info]
+            + default_variables_access_level_rbs
 
             + [urwid.AttrMap(urwid.Text("\nWrap Variables:\n"), "group head")]
             + [cb_wrap_variables]

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -72,7 +72,7 @@ class InspectInfo(object):
         self.display_type = CONFIG["stringifier"]
         self.highlighted = False
         self.repeated_at_top = False
-        self.access_level = CONFIG["variables_access_level"]
+        self.access_level = CONFIG["default_variables_access_level"]
         self.show_methods = False
         self.wrap = CONFIG["wrap_variables"]
 

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -72,7 +72,7 @@ class InspectInfo(object):
         self.display_type = CONFIG["stringifier"]
         self.highlighted = False
         self.repeated_at_top = False
-        self.access_level = "public"
+        self.access_level = CONFIG["variables_access_level"]
         self.show_methods = False
         self.wrap = CONFIG["wrap_variables"]
 


### PR DESCRIPTION
Currently, all variables in the var view have the default access level of "public". This might be a sane default but users may wish to change their default to something else. E.g. I prefer to have "private" as default and so add a setting for the access level to be able to change the default.