### PR TITLE
Skip namespace packages in module listing

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1297,6 +1297,8 @@ class DebuggerUI(FrameVarInfoKeeper):
             def mod_exists(mod):
                 if not hasattr(mod, "__file__"):
                     return False
+                if mod.__file__ is None:
+                    return False
                 filename = mod.__file__
 
                 base, ext = splitext(filename)


### PR DESCRIPTION
Managed to hit this with two modules: `mpl_toolkits` and `sphinxcontrib` that don't have an `__init__.py`. It just started happening after the update to Python 3.7, but I'm not sure what changed.