### PR TITLE
Only avoid SetPropogatingDict in the builtin shell in Python 2

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1576,11 +1576,15 @@ class DebuggerUI(FrameVarInfoKeeper):
             sys.stdin = None
             sys.stderr = sys.stdout = StringIO()
             try:
-                # Don't use cmdline_get_namespace() here, it breaks things in
-                # Python 2 (issue #166).
-                eval(compile(cmd, "<pudb command line>", 'single'),
-                        self.debugger.curframe.f_globals,
-                        self.debugger.curframe.f_locals)
+                # Don't use cmdline_get_namespace() here in Python 2, as it
+                # breaks things (issue #166).
+                if PY3:
+                    eval(compile(cmd, "<pudb command line>", 'single'),
+                         cmdline_get_namespace())
+                else:
+                    eval(compile(cmd, "<pudb command line>", 'single'),
+                         self.debugger.curframe.f_globals,
+                         self.debugger.curframe.f_locals)
             except Exception:
                 tp, val, tb = sys.exc_info()
 


### PR DESCRIPTION
The issues with using a custom dict subclass to eval/exec are fixed in
Python 3. Without this, local functions in the shell cannot access global
variables (for instance, inside of list comprehensions).

See the discussion on issues #166 and #103.

To reproduce the issue, debug a function, and make sure you are inside a function frame (not at the top module level). Then type Ctrl-x to go to the shell and enter

```py
x = 5
list(filter(lambda s: x, [{}]))
```

In Python 3, you will see `[{}]`. In Python 2, you get

```
Traceback (most recent call last):
  File "<pudb command line>", line 1, in <module>
  File "<pudb command line>", line 1, in <lambda>
NameError: global name 'x' is not defined
```