### PR TITLE
fix issue with libedit messing up terminal state

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1853,9 +1853,21 @@ class DebuggerUI(FrameVarInfoKeeper):
 
             self.update_var_view()
 
+        def run_internal_shell(w, size, key, first_time=[True]):
+            frame = self.debugger.curframe
+            if first_time: self.screen.stop()
+            import pudb.shell as sh
+            histfile, ns = sh.readline_init(frame.f_globals, frame.f_locals)
+            ret = toggle_cmdline_focus(w, size, key)
+            sh.readline_fini(histfile)
+            if first_time:
+                self.screen.start()
+                first_time.pop()
+            return ret
+
         def run_cmdline(w, size, key):
             if CONFIG["shell"] == "internal":
-                return toggle_cmdline_focus(w, size, key)
+                return run_internal_shell(w, size, key)
             else:
                 return run_external_cmdline(w, size, key)
 

--- a/pudb/shell.py
+++ b/pudb/shell.py
@@ -72,14 +72,7 @@ class SetPropagatingDict(dict):
 
 custom_shell_dict = {}
 
-
-def run_classic_shell(globals, locals, first_time=[True]):
-    if first_time:
-        banner = "Hit Ctrl-D to return to PuDB."
-        first_time.pop()
-    else:
-        banner = ""
-
+def readline_init(globals, locals):
     ns = SetPropagatingDict([locals, globals], locals)
 
     from pudb.settings import get_save_config_path
@@ -98,14 +91,27 @@ def run_classic_shell(globals, locals, first_time=[True]):
         except IOError:
             pass
 
+    return hist_file, ns
+
+def readline_fini(hist_file):
+    if HAVE_READLINE:
+        readline.write_history_file(hist_file)
+
+def run_classic_shell(globals, locals, first_time=[True]):
+    if first_time:
+        banner = "Hit Ctrl-D to return to PuDB."
+        first_time.pop()
+    else:
+        banner = ""
+
+    hist_file, ns = readline_init(globals, locals)
+
     from code import InteractiveConsole
     cons = InteractiveConsole(ns)
 
     cons.interact(banner)
 
-    if HAVE_READLINE:
-        readline.write_history_file(hist_file)
-
+    readline_fini(hist_file)
 
 def run_bpython_shell(globals, locals):
     ns = SetPropagatingDict([locals, globals], locals)


### PR DESCRIPTION
when switching to the internal shell and using tab completion, libedit messes
up the terminal state, unless it uses the readline initialization routine that
the "classic" shell code uses as well.
additionally to that, it requires that the console screen is stopped before
doing that for the first time.

fixes #336