### PR TITLE
Move the readline import out of the top (module) level and add Jedi completion

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1492,7 +1492,11 @@ class DebuggerUI(FrameVarInfoKeeper):
                     coming_from="above")
 
         def cmdline_tab_complete(w, size, key):
-            from rlcompleter import Completer
+            try:
+                from jedi import Interpreter
+            except ImportError:
+                add_cmdline_content("Tab completion requires jedi to be installed.",
+                                    "command line output")
 
             text = self.cmdline_edit.edit_text
             pos = self.cmdline_edit.edit_pos
@@ -1500,30 +1504,9 @@ class DebuggerUI(FrameVarInfoKeeper):
             chopped_text = text[:pos]
             suffix = text[pos:]
 
-            # stolen from readline in the Python interactive shell
-            delimiters = " \t\n`~!@#$%^&*()-=+[{]}\\|;:\'\",<>/?"
-
-            complete_start_index = max(
-                    chopped_text.rfind(delim_i)
-                    for delim_i in delimiters)
-
-            if complete_start_index == -1:
-                prefix = ""
-            else:
-                prefix = chopped_text[:complete_start_index+1]
-                chopped_text = chopped_text[complete_start_index+1:]
-
-            state = 0
-            chopped_completions = []
-            completer = Completer(cmdline_get_namespace())
-            while True:
-                completion = completer.complete(chopped_text, state)
-
-                if not isinstance(completion, str):
-                    break
-
-                chopped_completions.append(completion)
-                state += 1
+            completions = Interpreter(chopped_text, [cmdline_get_namespace()]).completions()
+            full_completions = [i.name_with_symbols for i in completions]
+            chopped_completions = [i.complete for i in completions]
 
             def common_prefix(a, b):
                 for i, (a_i, b_i) in enumerate(zip(a, b)):
@@ -1546,16 +1529,16 @@ class DebuggerUI(FrameVarInfoKeeper):
                 return
 
             if (
-                    len(completed_chopped_text) == len(chopped_text)
-                    and len(chopped_completions) > 1):
+                    len(completed_chopped_text) == 0
+                    and len(completions) > 1):
                 add_cmdline_content(
-                        "   ".join(chopped_completions),
+                        "   ".join(full_completions),
                         "command line output")
                 return
 
             self.cmdline_edit.edit_text = \
-                    prefix+completed_chopped_text+suffix
-            self.cmdline_edit.edit_pos = len(prefix) + len(completed_chopped_text)
+                    chopped_text+completed_chopped_text+suffix
+            self.cmdline_edit.edit_pos = len(chopped_text) + len(completed_chopped_text)
 
         def cmdline_append_newline(w, size, key):
             self.cmdline_edit.insert_text("\n")

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1506,9 +1506,10 @@ class DebuggerUI(FrameVarInfoKeeper):
 
             try:
                 completions = Interpreter(chopped_text, [cmdline_get_namespace()]).completions()
-            except:
+            except Exception as e:
                 # Jedi sometimes produces errors. Ignore
-                return
+                add_cmdline_content("Could not tab complete (error jedi: %r)" % e)
+
             full_completions = [i.name_with_symbols for i in completions]
             chopped_completions = [i.complete for i in completions]
 

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1504,7 +1504,11 @@ class DebuggerUI(FrameVarInfoKeeper):
             chopped_text = text[:pos]
             suffix = text[pos:]
 
-            completions = Interpreter(chopped_text, [cmdline_get_namespace()]).completions()
+            try:
+                completions = Interpreter(chopped_text, [cmdline_get_namespace()]).completions()
+            except:
+                # Jedi sometimes produces errors. Ignore
+                return
             full_completions = [i.name_with_symbols for i in completions]
             chopped_completions = [i.complete for i in completions]
 

--- a/pudb/shell.py
+++ b/pudb/shell.py
@@ -26,14 +26,6 @@ else:
     HAVE_PTPYTHON = True
 
 
-try:
-    import readline
-    import rlcompleter
-    HAVE_READLINE = True
-except ImportError:
-    HAVE_READLINE = False
-
-
 # {{{ combined locals/globals dict
 
 class SetPropagatingDict(dict):
@@ -87,6 +79,13 @@ def run_classic_shell(globals, locals, first_time=[True]):
     hist_file = join(
             get_save_config_path(),
             "shell-history")
+
+    try:
+        import readline
+        import rlcompleter
+        HAVE_READLINE = True
+    except ImportError:
+        HAVE_READLINE = False
 
     if HAVE_READLINE:
         readline.set_completer(


### PR DESCRIPTION
This fixes #166. I have no idea why, but if readline is really libedit (like
for a system or python.org install on Mac), it causes the built in shell to
break the terminal inputs, but only when imported at the top level. If the
import is deferred, as far as I've seen, it doesn't happen.

CC @rofl0r