### PR TITLE
Add option to hide command window when not in use

### DIFF
--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -112,7 +112,7 @@ def load_config():
 
     conf_dict.setdefault("prompt_on_quit", True)
 
-    conf_dict.setdefault("hide_cmdline_win", True)
+    conf_dict.setdefault("hide_cmdline_win", False)
 
     def normalize_bool_inplace(name):
         try:

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -112,7 +112,7 @@ def load_config():
 
     conf_dict.setdefault("prompt_on_quit", True)
 
-    conf_dict.setdefault("jk_sidebar_scroll", False)
+    conf_dict.setdefault("hide_cmdline_win", True)
 
     def normalize_bool_inplace(name):
         try:
@@ -126,7 +126,7 @@ def load_config():
     normalize_bool_inplace("line_numbers")
     normalize_bool_inplace("wrap_variables")
     normalize_bool_inplace("prompt_on_quit")
-    normalize_bool_inplace("jk_sidebar_scroll")
+    normalize_bool_inplace("hide_cmdline_win")
 
     return conf_dict
 
@@ -167,8 +167,8 @@ def edit_config(ui, conf_dict):
     def _update_prompt_on_quit():
         pass
 
-    def _update_jk_sidebar_scroll():
-        pass
+    def _update_hide_cmdline_win():
+        ui.update_cmdline_win()
 
     def _update_current_stack_frame():
         ui.update_stack()
@@ -208,10 +208,10 @@ def edit_config(ui, conf_dict):
             conf_dict.update(new_conf_dict)
             _update_prompt_on_quit()
 
-        elif option == "jk_sidebar_scroll":
-            new_conf_dict["jk_sidebar_scroll"] = not check_box.get_state()
+        elif option == "hide_cmdline_win":
+            new_conf_dict["hide_cmdline_win"] = not check_box.get_state()
             conf_dict.update(new_conf_dict)
-            _update_jk_sidebar_scroll()
+            _update_hide_cmdline_win()
 
         elif option == "current_stack_frame":
             # only activate if the new state of the radio button is 'on'
@@ -255,10 +255,10 @@ def edit_config(ui, conf_dict):
             bool(conf_dict["prompt_on_quit"]), on_state_change=_update_config,
                 user_data=("prompt_on_quit", None))
 
-    cb_jk_sidebar_scroll = urwid.CheckBox("Use j/k keys for scrolling in "
-                                          "sidebar",
-            bool(conf_dict["jk_sidebar_scroll"]), on_state_change=_update_config,
-                user_data=("jk_sidebar_scroll", None))
+    hide_cmdline_win = urwid.CheckBox("Hide command line (Ctrl-X) window "
+                                      "when not in use",
+            bool(conf_dict["hide_cmdline_win"]), on_state_change=_update_config,
+                user_data=("hide_cmdline_win", None))
 
     # {{{ shells
 
@@ -423,14 +423,10 @@ def edit_config(ui, conf_dict):
 
     lb_contents = (
             [heading]
-            + [urwid.AttrMap(urwid.Text("Line Numbers:\n"), "group head")]
+            + [urwid.AttrMap(urwid.Text("General:\n"), "group head")]
             + [cb_line_numbers]
-
-            + [urwid.AttrMap(urwid.Text("\nPrompt on quit:\n"), "group head")]
             + [cb_prompt_on_quit]
-
-            + [urwid.AttrMap(urwid.Text("\nKeys:\n"), "group head")]
-            + [cb_jk_sidebar_scroll]
+            + [hide_cmdline_win]
 
             + [urwid.AttrMap(urwid.Text("\nShell:\n"), "group head")]
             + [shell_info]


### PR DESCRIPTION
I and I suspect many other users don't use the command line window at the bottom so this PR adds an option to hide it by default. It pops up in to view when you Ctrl-X to it, and hides when you Ctrl-X back to the source window. Apart from the room to view your code, I think pudb looks aesthetically better and more balanced with a single source window on the left, and the sidebar windows on the right. With the new option set off, pudb displays the command window all the time as it does now.

Also removed the redundant "jk_sidebar_scroll" option. jk scroll should just be always enabled in sidebars like in main source window. Happy to put this back if somebody can explain the point of needing it?