### PR TITLE
Fix errant command line expose after search

### DIFF
--- a/pudb/ui_tools.py
+++ b/pudb/ui_tools.py
@@ -239,12 +239,8 @@ class SearchController(object):
                     0, ("flow", None))
             lhs_col.widget_list.insert(0, self.search_AttrMap)
 
-            self.ui.columns.set_focus(lhs_col)
-            lhs_col.set_focus(self.search_AttrMap)
-        else:
-            self.ui.columns.set_focus(lhs_col)
-            lhs_col.set_focus(self.search_AttrMap)
-            #self.search_box.restart_search()
+        self.ui.columns.set_focus(lhs_col)
+        lhs_col.set_focus(self.search_AttrMap)
 
     def perform_search(self, dir, s=None, start=None, update_search_start=False):
         self.cancel_highlight()


### PR DESCRIPTION
In PR #353 I added the option to hide the command line window but I just
noticed that the window errantly appeared if you did a search. This
commit fixes that by changing the logic to actually create/delete the
window (like all other PUDB "hidden" windows) instead of merely setting
the display width to 0 as I was doing previously. It seems this is necessary
because URWID sometimes rebiases the widths itself and thus a 0 width
may get set to a non 0 value and thus be exposed.

I also fixed a bug which has always existed, even prior to my first PR
and that is if you opened a search, then did a ctrl+x to the command
window and then again back to the source window then the source window
would get focus instead of the search window. This commit fixes it so
that focus goes back to the search window, if it is still open.

The change to ui_tools.py is merely to remove a redundant "else" that I
noticed.