### PR TITLE
Fix errant command line expose after search

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -762,7 +762,7 @@ class DebuggerUI(FrameVarInfoKeeper):
         def change_rhs_box(name, index, direction, w, size, key):
             from pudb.settings import save_config
 
-            _, weight = self.rhs_col.item_types[index]
+            weight = self.rhs_col.item_types[index][1]
 
             if direction < 0:
                 if weight > 1/5:
@@ -1697,7 +1697,9 @@ class DebuggerUI(FrameVarInfoKeeper):
             if self.lhs_col.get_focus() is self.cmdline_sigwrap:
                 if CONFIG["hide_cmdline_win"]:
                     self.set_cmdline_state(False)
-                self.lhs_col.set_focus(self.source_attr)
+                self.lhs_col.set_focus(self.search_controller.search_AttrMap
+                        if self.search_controller.search_box else
+                        self.source_attr)
             else:
                 if CONFIG["hide_cmdline_win"]:
                     self.set_cmdline_state(True)
@@ -1730,14 +1732,14 @@ class DebuggerUI(FrameVarInfoKeeper):
             set_cmdline_default_size(1/2)
 
         def grow_cmdline(w, size, key):
-            _, weight = self.lhs_col.item_types[-1]
+            weight = self.cmdline_weight
 
             if weight < 5:
                 weight *= 1.25
                 set_cmdline_default_size(weight)
 
         def shrink_cmdline(w, size, key):
-            _, weight = self.lhs_col.item_types[-1]
+            weight = self.cmdline_weight
 
             if weight > 1/2:
                 weight /= 1.25
@@ -1777,7 +1779,7 @@ class DebuggerUI(FrameVarInfoKeeper):
         def grow_sidebar(w, size, key):
             from pudb.settings import save_config
 
-            _, weight = self.columns.column_types[1]
+            weight = self.columns.column_types[1][1]
 
             if weight < 5:
                 weight *= 1.25
@@ -1789,7 +1791,7 @@ class DebuggerUI(FrameVarInfoKeeper):
         def shrink_sidebar(w, size, key):
             from pudb.settings import save_config
 
-            _, weight = self.columns.column_types[1]
+            weight = self.columns.column_types[1][1]
 
             if weight > 1/5:
                 weight /= 1.25
@@ -1989,6 +1991,10 @@ class DebuggerUI(FrameVarInfoKeeper):
     # }}}
 
     # {{{ UI helpers
+    def reset_cmdline_size(self):
+        self.lhs_col.item_types[-1] = "weight", \
+                self.cmdline_weight if self.cmdline_on else 0
+
     def set_cmdline_size(self, weight=None):
         if weight is None:
             weight = self.cmdline_weight

--- a/pudb/ui_tools.py
+++ b/pudb/ui_tools.py
@@ -238,13 +238,10 @@ class SearchController(object):
             lhs_col.item_types.insert(
                     0, ("flow", None))
             lhs_col.widget_list.insert(0, self.search_AttrMap)
+            self.ui.reset_cmdline_size()
 
-            self.ui.columns.set_focus(lhs_col)
-            lhs_col.set_focus(self.search_AttrMap)
-        else:
-            self.ui.columns.set_focus(lhs_col)
-            lhs_col.set_focus(self.search_AttrMap)
-            #self.search_box.restart_search()
+        self.ui.columns.set_focus(lhs_col)
+        lhs_col.set_focus(self.search_AttrMap)
 
     def perform_search(self, dir, s=None, start=None, update_search_start=False):
         self.cancel_highlight()


### PR DESCRIPTION
In PR #353 I added the option to hide the command line window but I recently noticed that the window errantly appeared if you did a search. This commit fixes that by resetting the command line window weight to 0 if it should be hidden, after a search is activated. It seems this is necessary because URWID sometimes rebiases the widths itself and thus a 0 width may get set to a non 0 value and would be exposed.

I also fixed a bug which has always existed, even prior to my first PR and that is if you opened a search, then did a ctrl+x to the command window and then again back to the source window then the source window would get focus instead of the search window and then the search gets locked to an odd state. This commit fixes it so that focus goes back to the search window, if it is still open.

There is also a small change to ui_tools.py is merely to remove a redundant "else" that I noticed and some misc other tiny aesthetic code improvements that I noticed in debugger.py.

This PR completely supercedes my previous PR #362  fix for these issues because PR #362 did not correctly maintain the size of the command window if it was re-opened.