### PR TITLE
Show the value of numpy scalars when using the safe stringifier

### DIFF
--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -265,6 +265,9 @@ def type_stringifier(value):
     if HAVE_NUMPY and isinstance(value, numpy.ndarray):
         return text_type("ndarray %s %s") % (value.dtype, value.shape)
 
+    elif HAVE_NUMPY and isinstance(value, numpy.number):
+        return text_type("%s (%s)" % (value, value.dtype))
+
     elif isinstance(value, STR_SAFE_TYPES):
         try:
             return text_type(value)


### PR DESCRIPTION
A numpy scalar value is already included in the tests (the test doesn't test the exact output, only that it doesn't crash). 