### PR TITLE
Fix the logic for getting line numbers in Python 3.8

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,8 @@ jobs:
                 python.version: '2.7'
             Python36:
                 python.version: '3.6'
+            Python37:
+                python.version: '3.7'
 
     steps:
     -
@@ -38,8 +40,8 @@ jobs:
         vmImage: 'ubuntu-latest'
     strategy:
         matrix:
-            Python37:
-                python.version: '3.7'
+            Python38:
+                python.version: '3.8'
 
     steps:
     -
@@ -74,8 +76,8 @@ jobs:
         vmImage: 'ubuntu-latest'
     strategy:
         matrix:
-            Python37:
-                python.version: '3.7'
+            Python38:
+                python.version: '3.8'
 
     steps:
     -

--- a/pudb/lowlevel.py
+++ b/pudb/lowlevel.py
@@ -35,8 +35,13 @@ def generate_executable_lines_for_code(code):
     lineno = code.co_firstlineno
     yield lineno
     if PY3:
-        for c in code.co_lnotab[1::2]:
-            lineno += c
+        # See https://github.com/python/cpython/blob/master/Objects/lnotab_notes.txt
+        addr = 0
+        for addr_incr, line_incr in zip(code.co_lnotab[::2], code.co_lnotab[1::2]):
+            addr += addr_incr
+            if line_incr >= 0x80:
+                line_incr -= 0x100
+            lineno += line_incr
             yield lineno
     else:
         for c in code.co_lnotab[1::2]:

--- a/pudb/lowlevel.py
+++ b/pudb/lowlevel.py
@@ -80,7 +80,6 @@ def get_executable_lines_for_file(filename):
     return get_executable_lines_for_codes_recursive(codes)
 
 
-
 def get_breakpoint_invalid_reason(filename, lineno):
     # simple logic stolen from pdb
     import linecache

--- a/test/test_lowlevel.py
+++ b/test/test_lowlevel.py
@@ -32,3 +32,78 @@ def test_decode_lines():
         assert unicode_lines == list(decode_lines(iter(lines)))
     else:
         assert [l.decode('utf-8') for l in lines] == list(decode_lines(iter(lines)))
+
+
+# {{{ remove common indentation
+
+def _remove_common_indentation(code, require_leading_newline=True):
+    if "\n" not in code:
+        return code
+
+    if require_leading_newline and not code.startswith("\n"):
+        return code
+
+    lines = code.split("\n")
+    while lines[0].strip() == "":
+        lines.pop(0)
+    while lines[-1].strip() == "":
+        lines.pop(-1)
+
+    if lines:
+        base_indent = 0
+        while lines[0][base_indent] in " \t":
+            base_indent += 1
+
+        for line in lines[1:]:
+            if line[:base_indent].strip():
+                raise ValueError("inconsistent indentation")
+
+    return "\n".join(line[base_indent:] for line in lines)
+
+# }}}
+
+
+def test_executable_lines():
+    def get_exec_lines(src):
+        code = compile(
+                    _remove_common_indentation(test_code),
+                    "<tmp>", "exec")
+        from pudb.lowlevel import get_executable_lines_for_codes_recursive
+        return get_executable_lines_for_codes_recursive([code])
+
+    test_code = """
+        def main():
+            import pudb; pu.db
+            conf = ''. \\
+                replace('', '')
+
+            conf_tpl = ''  # <-- imposible to set breakpoint here
+
+        main()
+        """
+
+    assert get_exec_lines(test_code) == set([1, 2, 3, 4, 6, 8])
+
+    test_code = "a = 3*5\n" + 333 * "\n" + "b = 15"
+    if PY3:
+        assert get_exec_lines(test_code) == set([
+            1,
+            128,  # bogus,
+            255,  # bogus,
+            335
+            ])
+    else:
+        assert get_exec_lines(test_code) == set([
+            1,
+            256,  # bogus,
+            335
+            ])
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        from pytest import main
+        main([__file__])


### PR DESCRIPTION
This fixes an issue in Python 3.8 where some lines couldn't be breakpointed.

Fixes #366.

I tested this on the example file from the issue in 3.8, 3.7, and 3.5. I didn't do any other tests, so it's possible this breaks something. We also maybe should add a test for this to the test suite. 