### PR TITLE
Map up/down keys to command history prev/next

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -96,7 +96,7 @@ Shell-related:
     _/= - minimize/maximize inline shell (active in command line history)
 
     Ctrl-v - insert newline
-    Ctrl-n/p - browse command line history
+    Arrow Down/Up - browse command line history
     Tab - yes, there is (simple) tab completion
 """
 

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1769,6 +1769,8 @@ class DebuggerUI(FrameVarInfoKeeper):
         self.cmdline_edit_sigwrap.listen("enter", cmdline_exec)
         self.cmdline_edit_sigwrap.listen("ctrl n", cmdline_history_next)
         self.cmdline_edit_sigwrap.listen("ctrl p", cmdline_history_prev)
+        self.cmdline_edit_sigwrap.listen("down", cmdline_history_next)
+        self.cmdline_edit_sigwrap.listen("up", cmdline_history_prev)
         self.cmdline_edit_sigwrap.listen("esc", toggle_cmdline_focus)
         self.cmdline_edit_sigwrap.listen("ctrl d", toggle_cmdline_focus)
         self.cmdline_edit_sigwrap.listen("ctrl a", cmdline_start_of_line)


### PR DESCRIPTION
Map up/down keys to command history prev/next when command line is focused

Fixes #348 