### PR TITLE
Let pytest versions float to match CI scripts

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,9 +3,9 @@ coverage==4.3.4
 pbr==2.0.0
 py==1.4.33
 Pygments==2.2.0
-pytest==3.0.7
-pytest-cov==2.4.0
-pytest-mock==1.10.0
+pytest
+pytest-cov
+pytest-mock
 six==1.10.0
 urwid==1.3.1
 numpy


### PR DESCRIPTION
Addresses a CI failure: https://gitlab.tiker.net/inducer/pudb/-/jobs/137548