### PR TITLE
Use h/l in the variable to view to collapse/open the current container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ traceback*txt
 .cache/
 .coverage
 coverage.xml
+tags

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -527,7 +527,7 @@ class Debugger(bdb.Bdb):
 from pudb.ui_tools import make_hotkey_markup, labelled_value, \
         SelectableText, SignalWrap, StackFrame, BreakpointFrame
 
-from pudb.var_view import FrameVarInfoKeeper, ValueWalker
+from pudb.var_view import FrameVarInfoKeeper
 
 
 # {{{ display setup

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -108,6 +108,8 @@ Sidebar-related (active in sidebar):
 
 Keys in variables list:
     \/enter/space - expand/collapse
+    h - collapse
+    l - expand
     t/r/s/c - show type/repr/str/custom for this variable
     H - toggle highlighting
     @ - toggle repetition at top

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -29,7 +29,6 @@ THE SOFTWARE.
 """
 
 
-import __builtin__
 import urwid
 import bdb
 import gc
@@ -893,7 +892,7 @@ class DebuggerUI(FrameVarInfoKeeper):
                 desired_prefix = var.prefix[:-len(ValueWalker.PREFIX)]
                 try:
                     # Walk backwards to find first shorter prefix
-                    parent = __builtin__.next(
+                    parent = next(
                         variable_widget
                         for variable_widget in reversed(self.locals[:pos+1])
                         if variable_widget.prefix == desired_prefix
@@ -1257,7 +1256,7 @@ class DebuggerUI(FrameVarInfoKeeper):
             self.debugger.save_breakpoints()
             self.quit_event_loop = True
 
-        def next(w, size, key):
+        def next_line(w, size, key):
             if self.debugger.post_mortem:
                 self.message("Post-mortem mode: Can't modify state.")
             else:
@@ -1558,7 +1557,7 @@ class DebuggerUI(FrameVarInfoKeeper):
         def helpmain(w, size, key):
             help(HELP_HEADER + HELP_MAIN + HELP_SIDE + HELP_LICENSE)
 
-        self.source_sigwrap.listen("n", next)
+        self.source_sigwrap.listen("n", next_line)
         self.source_sigwrap.listen("s", step)
         self.source_sigwrap.listen("f", finish)
         self.source_sigwrap.listen("r", finish)

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -891,13 +891,13 @@ class DebuggerUI(FrameVarInfoKeeper):
                 iinfo.show_detail = False
             else:
                 # Complex case: collapse parent/container variable
-                desired_prefix = var.prefix[:-len(ValueWalker.PREFIX)]
+                desired_level = max(0, var.nesting_level - 1)
                 try:
                     # Walk backwards to find first shorter prefix
                     parent = next(
                         variable_widget
                         for variable_widget in reversed(self.locals[:pos+1])
-                        if variable_widget.prefix == desired_prefix
+                        if variable_widget.nesting_level == desired_level
                     )
                 except StopIteration:
                     # No parent found, so don't do anything

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -559,7 +559,7 @@ SEPARATOR = urwid.AttrMap(urwid.Text(""), "variable separator")
 
 def make_var_view(frame_var_info, locals, globals):
     vars = list(locals.keys())
-    vars.sort(key=lambda n: n.lower())
+    vars.sort(key=str.lower)
 
     tmv_walker = TopAndMainVariableWalker(frame_var_info)
     ret_walker = BasicValueWalker(frame_var_info)


### PR DESCRIPTION
This behaves similarly to, for example, tmux's interactive session/window/pane selection.
I did see that h/l were supposed to be mapped to movement in the RHS column already, but this doesn't seem to work for me, and I believe this is a more useful interaction anyway. That said, I'm happy to move it this functionality to a different key.

The benefit is that you can open a huge container, navigate down through it, then when you're done you don't have to scroll all the way back up; just slap 'h'.