### PR TITLE
Use isroutine instead of ismethod to detect functions

### DIFF
--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -476,7 +476,7 @@ class ValueWalker:
 
                 try:
                     attr_value = getattr(value, key)
-                    if inspect.ismethod(attr_value) and not iinfo.show_methods:
+                    if inspect.isroutine(attr_value) and not iinfo.show_methods:
                         cnt_omitted_methods += 1
                         continue
                 except Exception:


### PR DESCRIPTION
ismethod misses functions whose implementation is not in python. We could split hairs and provide another action for toggling whether non-python/builtin functions on a given variable are visible, but I propose that this is easier, and probably what the user usually wants to do anyway.

An example where this would be useful is working with PySide (Qt for python).