### PR TITLE
add debugger for forked processes

### DIFF
--- a/doc/starting.rst
+++ b/doc/starting.rst
@@ -81,7 +81,7 @@ connection::
     pudb:6899: Waiting for client...
 
 Using the debugger after forking
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In a forked process no tty is attached usually, which leads to
 ``TypeError: ord() expected a character, but string of length 0 found``

--- a/doc/starting.rst
+++ b/doc/starting.rst
@@ -101,8 +101,7 @@ Running it with standard pudb breaks::
     PYTHONBREAKPOINT=pudb.set_trace python script.py
 
 However, on Unix system, e.g. Linux & MacOS, debugging a forked
-process is supported using ``pudb.forked.set_trace``, which redirects
-in- and output to ``/dev/stdin`` & ``/dev/stdout``::
+process is supported using ``pudb.forked.set_trace``::
 
     PYTHONBREAKPOINT=pudb.forked.set_trace python script.py
 

--- a/doc/starting.rst
+++ b/doc/starting.rst
@@ -80,21 +80,33 @@ connection::
     pudb:6899: Please telnet into 127.0.0.1 6899.
     pudb:6899: Waiting for client...
 
-Debugging forked processes
+Using the debugger after forking
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-On Unix system, e.g. Linux & MacOS e.g. Linux & MacOS, debugging a forked
-process is supported::
+In a forked process no tty is attached usually, which leads to
+``TypeError: ord() expected a character, but string of length 0 found``
+when debugging with standard pudb. E.g. consider this ``script.py``::
 
-    from pudb.forked import set_trace
-    set_trace()
+    from multiprocessing import Process
+    def f(name):
+        # breakpoint was introduced in Python 3.7
+        breakpoint()
+        print('hello', name)
     
-Or use it with Python's built-in ``breakpoint()`` (from Python 3.7)::
+    p = Process(target=f, args=('bob',))
+    p.start()
+    p.join()
 
-    export PYTHONBREAKPOINT=pudb.forked.set_trace
-    your-command  # using breakpoint() in the code
+Running it with standard pudb breaks::
 
-In- and output will be redirected to ``/dev/stdin`` & ``/dev/stdout``.
+    PYTHONBREAKPOINT=pudb.set_trace python script.py
+
+However, on Unix system, e.g. Linux & MacOS, debugging a forked
+process is supported using ``pudb.forked.set_trace``, which redirects
+in- and output to ``/dev/stdin`` & ``/dev/stdout``::
+
+    PYTHONBREAKPOINT=pudb.forked.set_trace python script.py
+
 
 Usage with pytest
 ^^^^^^^^^^^^^^^^^

--- a/doc/starting.rst
+++ b/doc/starting.rst
@@ -80,6 +80,22 @@ connection::
     pudb:6899: Please telnet into 127.0.0.1 6899.
     pudb:6899: Waiting for client...
 
+Debugging forked processes
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+On Unix system, e.g. Linux & MacOS e.g. Linux & MacOS, debugging a forked
+process is supported::
+
+    from pudb.forked import set_trace
+    set_trace()
+    
+Or use it with Python's built-in ``breakpoint()`` (from Python 3.7)::
+
+    export PYTHONBREAKPOINT=pudb.forked.set_trace
+    your-command  # using breakpoint() in the code
+
+In- and output will be redirected to ``/dev/stdin`` & ``/dev/stdout``.
+
 Usage with pytest
 ^^^^^^^^^^^^^^^^^
 

--- a/doc/starting.rst
+++ b/doc/starting.rst
@@ -83,7 +83,7 @@ connection::
 Using the debugger after forking
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In a forked process no TTY is usually attached to stdin/stdout, which leads to errors
+In a forked process, no TTY is usually attached to stdin/stdout, which leads to errors
 when debugging with standard pudb. E.g. consider this ``script.py``::
 
     from multiprocessing import Process
@@ -100,7 +100,7 @@ Running it with standard pudb breaks::
 
     PYTHONBREAKPOINT=pudb.set_trace python script.py
 
-However, on Unix system, e.g. Linux & MacOS, debugging a forked
+However, on Unix systems, e.g. Linux & MacOS, debugging a forked
 process is supported using ``pudb.forked.set_trace``::
 
     PYTHONBREAKPOINT=pudb.forked.set_trace python script.py

--- a/doc/starting.rst
+++ b/doc/starting.rst
@@ -83,8 +83,7 @@ connection::
 Using the debugger after forking
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In a forked process no tty is attached usually, which leads to
-``TypeError: ord() expected a character, but string of length 0 found``
+In a forked process no TTY is usually attached to stdin/stdout, which leads to errors
 when debugging with standard pudb. E.g. consider this ``script.py``::
 
     from multiprocessing import Process

--- a/pudb/forked.py
+++ b/pudb/forked.py
@@ -12,9 +12,10 @@ from pudb.debugger import Debugger
 
 
 def set_trace():
-    """Set a breakpoint in a forked process on Unix system, e.g. Linux & MacOS e.g. Linux & MacOS.
+    """Set a breakpoint in a forked process on Unix system, e.g. Linux & MacOS.
     In- and output will be redirected to /dev/stdin & /dev/stdout.
-    You can call pudb.forked.set_trace() directly or use it with python's built-in breakpoint():
+    You can call pudb.forked.set_trace() directly or
+    use it with python's built-in breakpoint():
     PYTHONBREAKPOINT=pudb.forked.set_trace python …
     """
     frame = sys._getframe().f_back

--- a/pudb/forked.py
+++ b/pudb/forked.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+
+import sys
+import fcntl
+import termios
+import struct
+
+from pudb.debugger import Debugger
+
+def forked_pudb():
+    frame = sys._getframe().f_back
+    try:
+        # Getting terminal size
+        s = struct.unpack(
+            "hh",
+            fcntl.ioctl(1, termios.TIOCGWINSZ, "1234"),
+        )
+        term_size = (s[1], s[0])
+    except Exception:
+        term_size = (80, 24)
+
+    Debugger(
+        stdin=open("/dev/stdin"), stdout=open("/dev/stdout", "w"), term_size=term_size
+    ).set_trace(frame)

--- a/pudb/forked.py
+++ b/pudb/forked.py
@@ -11,7 +11,12 @@ import struct
 from pudb.debugger import Debugger
 
 
-def forked_pudb():
+def set_trace():
+    """Set a breakpoint in a forked process on Unix system, e.g. Linux & MacOS e.g. Linux & MacOS.
+    In- and output will be redirected to /dev/stdin & /dev/stdout.
+    You can call pudb.forked.set_trace() directly or use it with python's built-in breakpoint():
+    PYTHONBREAKPOINT=pudb.forked.set_trace python …
+    """
     frame = sys._getframe().f_back
     try:
         # Getting terminal size

--- a/pudb/forked.py
+++ b/pudb/forked.py
@@ -10,6 +10,7 @@ import struct
 
 from pudb.debugger import Debugger
 
+
 def forked_pudb():
     frame = sys._getframe().f_back
     try:
@@ -23,5 +24,7 @@ def forked_pudb():
         term_size = (80, 24)
 
     Debugger(
-        stdin=open("/dev/stdin"), stdout=open("/dev/stdout", "w"), term_size=term_size
+        stdin=open("/dev/stdin"),
+        stdout=open("/dev/stdout", "w"),
+        term_size=term_size,
     ).set_trace(frame)

--- a/pudb/forked.py
+++ b/pudb/forked.py
@@ -11,26 +11,28 @@ import struct
 from pudb.debugger import Debugger
 
 
-def set_trace():
+def set_trace(paused=True, frame=None, term_size=None):
     """Set a breakpoint in a forked process on Unix system, e.g. Linux & MacOS.
     In- and output will be redirected to /dev/stdin & /dev/stdout.
     You can call pudb.forked.set_trace() directly or
     use it with python's built-in breakpoint():
     PYTHONBREAKPOINT=pudb.forked.set_trace python …
     """
-    frame = sys._getframe().f_back
-    try:
-        # Getting terminal size
-        s = struct.unpack(
-            "hh",
-            fcntl.ioctl(1, termios.TIOCGWINSZ, "1234"),
-        )
-        term_size = (s[1], s[0])
-    except Exception:
-        term_size = (80, 24)
+    if frame is None:
+        frame = sys._getframe().f_back
+    if term_size is None:
+        try:
+            # Getting terminal size
+            s = struct.unpack(
+                "hh",
+                fcntl.ioctl(1, termios.TIOCGWINSZ, "1234"),
+            )
+            term_size = (s[1], s[0])
+        except Exception:
+            term_size = (80, 24)
 
     Debugger(
         stdin=open("/dev/stdin"),
         stdout=open("/dev/stdout", "w"),
         term_size=term_size,
-    ).set_trace(frame)
+    ).set_trace(frame, paused=paused)


### PR DESCRIPTION
This PR adds a version of pudb that can be used from forked processes without using telnet. 

related to #28

Thanks for considering this PR! I'm happy to adapt anything if needed.