### PR TITLE
Provide an option to log unexpected exceptions from pudb to stderr

### DIFF
--- a/doc/starting.rst
+++ b/doc/starting.rst
@@ -66,6 +66,15 @@ Now instead of using the current terminal, pudb will use this tty for its UI.
 You may want to use the internal shell in pudb, as others will still use the
 original terminal.
 
+Logging Internal Errors
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Some kinds of internal exceptions encountered by pudb will be logged to the
+terminal window when the debugger is active. To send these messages to a file
+instead, use the ``--log-errors`` flag::
+
+    python -m pudb --log-errors pudberrors.log
+
 Remote debugging
 ^^^^^^^^^^^^^^^^
 

--- a/doc/starting.rst
+++ b/doc/starting.rst
@@ -80,20 +80,6 @@ connection::
     pudb:6899: Please telnet into 127.0.0.1 6899.
     pudb:6899: Waiting for client...
 
-Logging Errors
-^^^^^^^^^^^^^^
-
-Unexpected exceptions encountered by pudb internals are suppressed by default.
-You can use the ``--log-errors`` flag to have these exceptions logged to stderr.
-This works best if you pipe stderr to a file and watch the log from another
-terminal::
-
-    python -m pudb --log-errors debug_me.py 2> errors.log
-    
-And then in another shell::
-
-    tail -f errors.log
-    
 Usage with pytest
 ^^^^^^^^^^^^^^^^^
 

--- a/doc/starting.rst
+++ b/doc/starting.rst
@@ -18,7 +18,7 @@ If you are using Python 3.7 or newer, you can add::
     # Set breakpoint() in Python to call pudb
     export PYTHONBREAKPOINT="pudb.set_trace"
 
-in your ~/.bashrc. Then use::
+in your ``~/.bashrc``. Then use::
 
     breakpoint()
 
@@ -50,12 +50,12 @@ original terminal available for any other reason.
 
 Open a new terminal. First, you need to get the path of the tty of the
 terminal you want to debug from. To do that, use the standard unix
-command `tty`. It will print something like `/dev/pts/3`.
+command ``tty``. It will print something like ``/dev/pts/3``.
 
 Then you need to make sure that your terminal doesn't have a shell actively
 reading and possibly capturing some of the input that should go to pudb.
 To do that run a placeholder command that does nothing,
-such as `perl -MPOSIX -e pause`.
+such as ``perl -MPOSIX -e pause``.
 
 Then set the PUDB_TTY environment variable to the path tty gave you,
 for example::
@@ -80,6 +80,20 @@ connection::
     pudb:6899: Please telnet into 127.0.0.1 6899.
     pudb:6899: Waiting for client...
 
+Logging Errors
+^^^^^^^^^^^^^^
+
+Unexpected exceptions encountered by pudb internals are suppressed by default.
+You can use the ``--log-errors`` flag to have these exceptions logged to stderr.
+This works best if you pipe stderr to a file and watch the log from another
+terminal::
+
+    python -m pudb --log-errors debug_me.py 2> errors.log
+    
+And then in another shell::
+
+    tail -f errors.log
+    
 Usage with pytest
 ^^^^^^^^^^^^^^^^^
 

--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -26,15 +26,13 @@ THE SOFTWARE.
 """
 
 
+from pudb.py3compat import raw_input, PY3
+from pudb.settings import load_config
+
+
 NUM_VERSION = (2020, 1)
 VERSION = ".".join(str(nv) for nv in NUM_VERSION)
 __version__ = VERSION
-
-from pudb.py3compat import raw_input, PY3
-
-from pudb.settings import load_config, save_config
-CONFIG = load_config()
-save_config(CONFIG)
 
 
 class PudbShortcuts(object):
@@ -184,7 +182,7 @@ def runscript(mainpyfile, args=None, pre_run="", steal_output=False,
             import urwid
             pre_run_edit = urwid.Edit("", pre_run)
 
-            if not CONFIG["prompt_on_quit"]:
+            if not load_config()["prompt_on_quit"]:
                 return
 
             result = dbg.ui.call_with_ui(dbg.ui.dialog,

--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -115,6 +115,10 @@ def _get_debugger(**kwargs):
         return CURRENT_DEBUGGER[0]
 
 
+def _have_debugger():
+    return len(CURRENT_DEBUGGER) > 0
+
+
 import signal  # noqa
 DEFAULT_SIGNAL = signal.SIGINT
 del signal

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -2613,7 +2613,9 @@ class DebuggerUI(FrameVarInfoKeeper):
                     class_name = frame.f_locals["self"].__class__.__name__
                 except Exception:
                     from pudb.lowlevel import ui_log
-                    ui_log.exception('Failed to determine class name')
+                    message = 'Failed to determine class name'
+                    ui_log.exception(message)
+                    class_name = '!! %s !!' % message
 
             return StackFrame(frame is self.debugger.curframe,
                     code.co_name, class_name,

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1595,6 +1595,7 @@ class DebuggerUI(FrameVarInfoKeeper):
             self.cmdline_list.set_focus_valign("bottom")
             self.cmdline_list.set_focus(len(self.cmdline_contents) - 1,
                     coming_from="above")
+        self.add_cmdline_content = add_cmdline_content
 
         def cmdline_tab_complete(w, size, key):
             try:

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1583,25 +1583,11 @@ class DebuggerUI(FrameVarInfoKeeper):
                     [curframe.f_locals, curframe.f_globals],
                     curframe.f_locals)
 
-        def add_cmdline_content(s, attr):
-            s = s.rstrip("\n")
-
-            from pudb.ui_tools import SelectableText
-            self.cmdline_contents.append(
-                    urwid.AttrMap(SelectableText(s),
-                        attr, "focused "+attr))
-
-            # scroll to end of last entry
-            self.cmdline_list.set_focus_valign("bottom")
-            self.cmdline_list.set_focus(len(self.cmdline_contents) - 1,
-                    coming_from="above")
-        self.add_cmdline_content = add_cmdline_content
-
         def cmdline_tab_complete(w, size, key):
             try:
                 from jedi import Interpreter
             except ImportError:
-                add_cmdline_content(
+                self.add_cmdline_content(
                         "Tab completion requires jedi to be installed. ",
                         "command line error")
                 return
@@ -1609,7 +1595,7 @@ class DebuggerUI(FrameVarInfoKeeper):
             import jedi
             from distutils.version import LooseVersion
             if LooseVersion(jedi.__version__) < LooseVersion("0.16.0"):
-                add_cmdline_content(
+                self.add_cmdline_content(
                         "jedi 0.16.0 is required for Tab completion",
                         "command line error")
 
@@ -1625,7 +1611,7 @@ class DebuggerUI(FrameVarInfoKeeper):
                         [cmdline_get_namespace()]).complete()
             except Exception as e:
                 # Jedi sometimes produces errors. Ignore them.
-                add_cmdline_content(
+                self.add_cmdline_content(
                         "Could not tab complete (Jedi error: '%s')" % e,
                         "command line error")
                 return
@@ -1656,7 +1642,7 @@ class DebuggerUI(FrameVarInfoKeeper):
             if (
                     len(completed_chopped_text) == 0
                     and len(completions) > 1):
-                add_cmdline_content(
+                self.add_cmdline_content(
                         "   ".join(full_completions),
                         "command line output")
                 return
@@ -1676,7 +1662,7 @@ class DebuggerUI(FrameVarInfoKeeper):
                 # blank command -> refuse service
                 return
 
-            add_cmdline_content(">>> " + cmd, "command line input")
+            self.add_cmdline_content(">>> " + cmd, "command line input")
 
             if not self.cmdline_history or cmd != self.cmdline_history[-1]:
                 self.cmdline_history.append(cmd)
@@ -1716,12 +1702,12 @@ class DebuggerUI(FrameVarInfoKeeper):
                     tb_lines.insert(0, "Traceback (most recent call last):\n")
                 tb_lines[len(tb_lines):] = traceback.format_exception_only(tp, val)
 
-                add_cmdline_content("".join(tb_lines), "command line error")
+                self.add_cmdline_content("".join(tb_lines), "command line error")
             else:
                 self.cmdline_edit.set_edit_text("")
             finally:
                 if sys.stdout.getvalue():
-                    add_cmdline_content(sys.stdout.getvalue(), "command line output")
+                    self.add_cmdline_content(sys.stdout.getvalue(), "command line output")
 
                 sys.stdin = prev_sys_stdin
                 sys.stdout = prev_sys_stdout
@@ -2074,6 +2060,18 @@ class DebuggerUI(FrameVarInfoKeeper):
     # }}}
 
     # {{{ UI helpers
+    def add_cmdline_content(self, s, attr):
+        s = s.rstrip("\n")
+
+        from pudb.ui_tools import SelectableText
+        self.cmdline_contents.append(
+                urwid.AttrMap(SelectableText(s), attr, "focused "+attr))
+
+        # scroll to end of last entry
+        self.cmdline_list.set_focus_valign("bottom")
+        self.cmdline_list.set_focus(len(self.cmdline_contents) - 1,
+                coming_from="above")
+
     def reset_cmdline_size(self):
         self.lhs_col.item_types[-1] = "weight", \
                 self.cmdline_weight if self.cmdline_on else 0

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -2613,7 +2613,8 @@ class DebuggerUI(FrameVarInfoKeeper):
                 try:
                     class_name = frame.f_locals["self"].__class__.__name__
                 except Exception:
-                    pass
+                    from pudb.lowlevel import ui_log
+                    ui_log.exception('Failed to determine class name')
 
             return StackFrame(frame is self.debugger.curframe,
                     code.co_name, class_name,

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -2072,6 +2072,9 @@ class DebuggerUI(FrameVarInfoKeeper):
         self.cmdline_list.set_focus(len(self.cmdline_contents) - 1,
                 coming_from="above")
 
+        # Force the commandline to be visible
+        self.set_cmdline_state(True)
+
     def reset_cmdline_size(self):
         self.lhs_col.item_types[-1] = "weight", \
                 self.cmdline_weight if self.cmdline_on else 0

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1707,7 +1707,8 @@ class DebuggerUI(FrameVarInfoKeeper):
                 self.cmdline_edit.set_edit_text("")
             finally:
                 if sys.stdout.getvalue():
-                    self.add_cmdline_content(sys.stdout.getvalue(), "command line output")
+                    self.add_cmdline_content(sys.stdout.getvalue(),
+                                             "command line output")
 
                 sys.stdin = prev_sys_stdin
                 sys.stdout = prev_sys_stdout

--- a/pudb/lowlevel.py
+++ b/pudb/lowlevel.py
@@ -33,11 +33,11 @@ from pudb.py3compat import PY3, text_type
 logfile = [None]
 
 
-def getLogfile():
+def getlogfile():
     return logfile[0]
 
 
-def setLogfile(destfile):
+def setlogfile(destfile):
     logfile[0] = destfile
     with open(destfile, 'a') as openfile:
         openfile.write(
@@ -53,7 +53,7 @@ class TerminalOrStreamHandler(logging.StreamHandler):
     """
     def emit(self, record):
         from pudb import _have_debugger, _get_debugger
-        logfile = getLogfile()
+        logfile = getlogfile()
 
         self.acquire()
         try:

--- a/pudb/lowlevel.py
+++ b/pudb/lowlevel.py
@@ -28,6 +28,26 @@ THE SOFTWARE.
 
 from pudb.py3compat import PY3, text_type
 
+import logging
+
+ui_formatter = logging.Formatter(
+    fmt='\n*** Pudb UI Exception Encountered: %(message)s ***\n'
+)
+ui_handler = logging.StreamHandler()
+ui_handler.setFormatter(ui_formatter)
+ui_log = logging.getLogger('ui')
+ui_log.setLevel(logging.CRITICAL)
+ui_log.addHandler(ui_handler)
+
+settings_formatter = logging.Formatter(
+    fmt='\n*** Pudb Settings Exception Encountered: %(message)s ***\n'
+)
+settings_handler = logging.StreamHandler()
+settings_handler.setFormatter(settings_formatter)
+settings_log = logging.getLogger('settings')
+settings_log.setLevel(logging.CRITICAL)
+settings_log.addHandler(settings_handler)
+
 
 # {{{ breakpoint validity
 

--- a/pudb/lowlevel.py
+++ b/pudb/lowlevel.py
@@ -30,10 +30,23 @@ from pudb.py3compat import PY3, text_type
 
 import logging
 
+
+class SafeStreamHandler(logging.StreamHandler):
+    """
+    Logging stream handler that clears up the UI when it's done, if needed.
+    """
+    def emit(self, record):
+        from pudb import _have_debugger, _get_debugger
+        super(SafeStreamHandler, self).emit(record)
+        if _have_debugger():
+            dbg = _get_debugger()
+            dbg.ui.screen.clear()
+
+
 ui_formatter = logging.Formatter(
     fmt='\n*** Pudb UI Exception Encountered: %(message)s ***\n'
 )
-ui_handler = logging.StreamHandler()
+ui_handler = SafeStreamHandler()
 ui_handler.setFormatter(ui_formatter)
 ui_log = logging.getLogger('ui')
 ui_log.setLevel(logging.CRITICAL)
@@ -42,7 +55,7 @@ ui_log.addHandler(ui_handler)
 settings_formatter = logging.Formatter(
     fmt='\n*** Pudb Settings Exception Encountered: %(message)s ***\n'
 )
-settings_handler = logging.StreamHandler()
+settings_handler = SafeStreamHandler()
 settings_handler.setFormatter(settings_formatter)
 settings_log = logging.getLogger('settings')
 settings_log.setLevel(logging.CRITICAL)

--- a/pudb/lowlevel.py
+++ b/pudb/lowlevel.py
@@ -49,7 +49,6 @@ ui_formatter = logging.Formatter(
 ui_handler = SafeStreamHandler()
 ui_handler.setFormatter(ui_formatter)
 ui_log = logging.getLogger('ui')
-ui_log.setLevel(logging.CRITICAL)
 ui_log.addHandler(ui_handler)
 
 settings_formatter = logging.Formatter(
@@ -58,7 +57,6 @@ settings_formatter = logging.Formatter(
 settings_handler = SafeStreamHandler()
 settings_handler.setFormatter(settings_formatter)
 settings_log = logging.getLogger('settings')
-settings_log.setLevel(logging.CRITICAL)
 settings_log.addHandler(settings_handler)
 
 

--- a/pudb/run.py
+++ b/pudb/run.py
@@ -15,16 +15,26 @@ def main():
     #    python -m pudb -m http.server -h
     # where the -h will be passed to the http.server module
     parser.add_argument("-m", "--module", action='store_true',
-                      help="Debug as module or package instead of as a script")
+                        help="Debug as module or package instead of as a script")
 
+    parser.add_argument("-le", "--log-errors", action='store_true',
+                        help="If an unexpected exception is encountered, "
+                             "log the exception information to stderr",
+                        default=False)
     parser.add_argument("--pre-run", metavar="COMMAND",
-            help="Run command before each program run",
-            default="")
+                        help="Run command before each program run",
+                        default="")
     parser.add_argument('script_args', nargs=argparse.REMAINDER,
                         help="Arguments to pass to script or module")
 
     options = parser.parse_args()
     args = options.script_args
+
+    if options.log_errors:
+        import logging
+        from pudb.lowlevel import ui_log, settings_log
+        ui_log.setLevel(logging.ERROR)
+        settings_log.setLevel(logging.ERROR)
 
     options_kwargs = {
         'pre_run': options.pre_run,

--- a/pudb/run.py
+++ b/pudb/run.py
@@ -29,8 +29,8 @@ def main():
     args = options.script_args
 
     if options.log_errors:
-        from pudb.lowlevel import setLogfile
-        setLogfile(options.log_errors[0])
+        from pudb.lowlevel import setlogfile
+        setlogfile(options.log_errors[0])
 
     options_kwargs = {
         'pre_run': options.pre_run,

--- a/pudb/run.py
+++ b/pudb/run.py
@@ -17,6 +17,8 @@ def main():
     parser.add_argument("-m", "--module", action='store_true',
                         help="Debug as module or package instead of as a script")
 
+    parser.add_argument("-le", "--log-errors", nargs=1, metavar='FILE',
+                        help="Log internal errors to the given file")
     parser.add_argument("--pre-run", metavar="COMMAND",
                         help="Run command before each program run",
                         default="")
@@ -25,6 +27,10 @@ def main():
 
     options = parser.parse_args()
     args = options.script_args
+
+    if options.log_errors:
+        from pudb.lowlevel import setLogfile
+        setLogfile(options.log_errors[0])
 
     options_kwargs = {
         'pre_run': options.pre_run,

--- a/pudb/run.py
+++ b/pudb/run.py
@@ -17,10 +17,6 @@ def main():
     parser.add_argument("-m", "--module", action='store_true',
                         help="Debug as module or package instead of as a script")
 
-    parser.add_argument("-le", "--log-errors", action='store_true',
-                        help="If an unexpected exception is encountered, "
-                             "log the exception information to stderr",
-                        default=False)
     parser.add_argument("--pre-run", metavar="COMMAND",
                         help="Run command before each program run",
                         default="")
@@ -29,12 +25,6 @@ def main():
 
     options = parser.parse_args()
     args = options.script_args
-
-    if options.log_errors:
-        import logging
-        from pudb.lowlevel import ui_log, settings_log
-        ui_log.setLevel(logging.ERROR)
-        settings_log.setLevel(logging.ERROR)
 
     options_kwargs = {
         'pre_run': options.pre_run,

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -25,12 +25,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-
 import os
 import sys
 
 from pudb.py3compat import ConfigParser
-from pudb.lowlevel import lookup_module, get_breakpoint_invalid_reason
+from pudb.lowlevel import (lookup_module, get_breakpoint_invalid_reason,
+                           settings_log)
 
 # minor LGPL violation: stolen from python-xdg
 
@@ -85,7 +85,7 @@ def load_config():
         if cparser.has_section(CONF_SECTION):
             conf_dict.update(dict(cparser.items(CONF_SECTION)))
     except Exception:
-        pass
+        settings_log.exception('Failed to load config')
 
     conf_dict.setdefault("shell", "internal")
     conf_dict.setdefault("theme", "classic")
@@ -121,7 +121,7 @@ def load_config():
             else:
                 conf_dict[name] = True
         except Exception:
-            pass
+            settings_log.exception('Failed to process config')
 
     normalize_bool_inplace("line_numbers")
     normalize_bool_inplace("wrap_variables")
@@ -148,7 +148,7 @@ def save_config(conf_dict):
         cparser.write(outf)
         outf.close()
     except Exception:
-        pass
+        settings_log.exception('Failed to save config')
 
 
 def edit_config(ui, conf_dict):

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -71,7 +71,14 @@ SAVED_BREAKPOINTS_FILE_NAME = "saved-breakpoints-%d.%d" % sys.version_info[:2]
 BREAKPOINTS_FILE_NAME = "breakpoints-%d.%d" % sys.version_info[:2]
 
 
+_config_ = [None]
+
+
 def load_config():
+    # Only ever do this once
+    if _config_[0] is not None:
+        return _config_[0]
+
     from os.path import join, isdir
 
     cparser = ConfigParser()
@@ -128,6 +135,7 @@ def load_config():
     normalize_bool_inplace("prompt_on_quit")
     normalize_bool_inplace("hide_cmdline_win")
 
+    _config_[0] = conf_dict
     return conf_dict
 
 

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -89,7 +89,7 @@ def load_config():
 
     conf_dict.setdefault("shell", "internal")
     conf_dict.setdefault("theme", "classic")
-    conf_dict.setdefault("line_numbers", False)
+    conf_dict.setdefault("line_numbers", "False")
     conf_dict.setdefault("seen_welcome", "a")
 
     conf_dict.setdefault("sidebar_width", 0.5)
@@ -105,14 +105,14 @@ def load_config():
     conf_dict.setdefault("custom_stringifier", "")
     conf_dict.setdefault("custom_shell", "")
 
-    conf_dict.setdefault("wrap_variables", True)
+    conf_dict.setdefault("wrap_variables", "True")
     conf_dict.setdefault("default_variables_access_level", "public")
 
     conf_dict.setdefault("display", "auto")
 
-    conf_dict.setdefault("prompt_on_quit", True)
+    conf_dict.setdefault("prompt_on_quit", "True")
 
-    conf_dict.setdefault("hide_cmdline_win", False)
+    conf_dict.setdefault("hide_cmdline_win", "False")
 
     def normalize_bool_inplace(name):
         try:

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -287,7 +287,9 @@ def type_stringifier(value):
         try:
             return text_type(value)
         except Exception:
-            ui_log.exception('string safe type stringifier failed')
+            message = 'string safe type stringifier failed'
+            ui_log.exception(message)
+            return '!! %s !!' % message
 
     elif hasattr(type(value), "safely_stringify_for_pudb"):
         try:
@@ -295,10 +297,12 @@ def type_stringifier(value):
             # and return nonsense.
             result = value.safely_stringify_for_pudb()
         except Exception:
-            ui_log.exception('safely_stringify_for_pudb call failed')
-        else:
-            if isinstance(result, string_types):
-                return text_type(result)
+            message = 'safely_stringify_for_pudb call failed'
+            ui_log.exception(message)
+            result = '!! %s !!' % message
+
+        if isinstance(result, string_types):
+            return text_type(result)
 
     elif type(value) in [set, frozenset, list, tuple, dict]:
         return text_type("%s (%s)") % (type(value).__name__, len(value))

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -465,7 +465,7 @@ class ValueWalker:
             try:
                 key_its.append(dir(value))
             except Exception:
-                ui_log.exception('Failed to lookup attributes')
+                ui_log.exception('Failed to look up attributes')
 
             keys = [key
                     for ki in key_its


### PR DESCRIPTION
It's not much, but it's a start towards making weird issues that are currently swallowed into the abyss a bit easier to debug. The loggers are set up to not write anything out by default, they're just there as something that can be turned on when we want to figure out why something strange is happening.

The logging calls themselves are a bit arbitrary and preliminary in this PR, the main thing I think is having a logging structure in place to begin with for these sorts of situations. Apologies if one already exists that I managed to overlook!

Very much open to feedback on this though, I wasn't sure what direction to go in so this is just a stab in the dark at something that could be useful.

On a related note, I think I'd like to take a pass at cleaning up settings.py, I think there's some odd behaviour in terms of where configs get loaded/saved to, and I think it would be nice if someone using this code as an API could specify a filename for saving/loading configs and/or breakpoint files. But that's for another day...

This is particularly in response to issue #355 