### PR TITLE
Make sure we can actually look up the values for keys to containers in the variable view

### DIFF
--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -417,7 +417,7 @@ class ValueWalker:
             if key_it is None:
                 try:
                     len_value = len(value)
-                except TypeError:
+                except (AttributeError, TypeError):
                     # no __len__ defined on the value, not worth mentioning!
                     pass
                 except Exception:
@@ -425,7 +425,7 @@ class ValueWalker:
                 else:
                     try:
                         value[0]
-                    except IndexError:
+                    except (LookupError, TypeError):
                         key_it = []
                     except Exception:
                         ui_log.exception("Item is not iterable")
@@ -445,7 +445,7 @@ class ValueWalker:
 
                     try:
                         next_value = value[key]
-                    except TypeError:
+                    except (LookupError, TypeError):
                         ui_log.exception("Failed to iterate an item that "
                             "appeared to be iterable.")
                         break

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -432,7 +432,7 @@ class ValueWalker:
                     else:
                         key_it = xrange(len_value)
 
-            if key_it is not None and hasattr(value, '__getitem__'):
+            if key_it is not None:
                 cnt = 0
                 for key in key_it:
                     if cnt % 10 == 0 and cnt:
@@ -443,7 +443,14 @@ class ValueWalker:
                                 new_parent_item, "...", None, cont_id_path)
                             break
 
-                    self.walk_value(new_parent_item, repr(key), value[key],
+                    try:
+                        next_value = value[key]
+                    except TypeError:
+                        ui_log.exception("Failed to iterate an item that "
+                            "appeared to be iterable.")
+                        break
+
+                    self.walk_value(new_parent_item, repr(key), next_value,
                         "%s[%r]" % (id_path, key))
                     cnt += 1
                 if not cnt:

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -432,7 +432,7 @@ class ValueWalker:
                     else:
                         key_it = xrange(len_value)
 
-            if key_it is not None:
+            if key_it is not None and hasattr(value, '__getitem__'):
                 cnt = 0
                 for key in key_it:
                     if cnt % 10 == 0 and cnt:


### PR DESCRIPTION
Defining keys() but not __getitem__ is a pretty big code smell, but that
doesn't mean we should crash.