### PR TITLE
Support ipython kernel as a shell

### DIFF
--- a/doc/shells.rst
+++ b/doc/shells.rst
@@ -54,10 +54,10 @@ PuDB supports the following external shells.
 - `IPython <https://ipython.org/>`_
    The `IPython` shell can also be used in a server-client fasion, which is
    enabled by selecting the shell `ipython_kernel` in the settings. When set,
-   the ``!`` key will start an `IPython` kernel and wait for connection from
-   `qtconsole`. Like other shells, `ipython_kernel` blocks the debugger UI
-   while it is active. Type `quit` or `exit` from a client to exit the kernel
-   and return to the debugger.
+   the ``!`` key will start an `IPython` kernel and wait for connection from,
+   e.g., `qtconsole`. Like other shells, `ipython_kernel` blocks the debugger
+   UI while it is active. Type `quit` or `exit` from a client to exit the
+   kernel and return to the debugger.
 - `bpython <https://bpython-interpreter.org/>`_
 - `ptpython <https://github.com/jonathanslenders/ptpython>`_
 

--- a/doc/shells.rst
+++ b/doc/shells.rst
@@ -52,15 +52,15 @@ PuDB supports the following external shells.
 - Internal (same as pressing ``Ctrl-x``). This is the default.
 - Classic (similar to the default ``python`` interactive shell)
 - `IPython <https://ipython.org/>`_
+   The `IPython` shell can also be used in a server-client fasion, which is
+   enabled by selecting the shell `ipython_kernel` in the settings. When set,
+   the ``!`` key will start an `IPython` kernel and wait for connection from
+   `qtconsole`. Like other shells, `ipython_kernel` blocks the debugger UI
+   while it is active. Type `quit` or `exit` from a client to exit the kernel
+   and return to the debugger.
 - `bpython <https://bpython-interpreter.org/>`_
 - `ptpython <https://github.com/jonathanslenders/ptpython>`_
 
-The `IPython` shell can also be used in a server-client fasion, which is
-enabled by selecting the shell `ipython_kernel` in the settings. When set, the
-``!`` key will start an `IPython` kernel and wait for connection from
-`qtconsole`. Like other shells, `ipython_kernel` blocks the debugger UI while
-it is active. Send "quit" from a client to exit the kernel and return to the
-debugger.
 
 Custom shells
 -------------

--- a/doc/shells.rst
+++ b/doc/shells.rst
@@ -55,6 +55,12 @@ PuDB supports the following external shells.
 - `bpython <https://bpython-interpreter.org/>`_
 - `ptpython <https://github.com/jonathanslenders/ptpython>`_
 
+The `IPython` shell can also be used in a server-client fasion. Select the
+shell `ipython_kernel` in the settings. When set, the ``!`` key will start an
+`IPython` kernel and wait for connection from `qtconsole`. Like other shells,
+`ipython_kernel` blocks the debugger UI while it is active. Send "quit" from a
+client to exit the kernel and return to the debugger.
+
 Custom shells
 -------------
 

--- a/doc/shells.rst
+++ b/doc/shells.rst
@@ -55,11 +55,12 @@ PuDB supports the following external shells.
 - `bpython <https://bpython-interpreter.org/>`_
 - `ptpython <https://github.com/jonathanslenders/ptpython>`_
 
-The `IPython` shell can also be used in a server-client fasion. Select the
-shell `ipython_kernel` in the settings. When set, the ``!`` key will start an
-`IPython` kernel and wait for connection from `qtconsole`. Like other shells,
-`ipython_kernel` blocks the debugger UI while it is active. Send "quit" from a
-client to exit the kernel and return to the debugger.
+The `IPython` shell can also be used in a server-client fasion, which is
+enabled by selecting the shell `ipython_kernel` in the settings. When set, the
+``!`` key will start an `IPython` kernel and wait for connection from
+`qtconsole`. Like other shells, `ipython_kernel` blocks the debugger UI while
+it is active. Send "quit" from a client to exit the kernel and return to the
+debugger.
 
 Custom shells
 -------------

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1920,7 +1920,7 @@ class DebuggerUI(FrameVarInfoKeeper):
             import pudb.shell as shell
             if CONFIG["shell"] == "ipython" and shell.have_ipython():
                 runner = shell.run_ipython_shell
-            elif CONFIG["shell"] == "ipython-kernel" and shell.have_ipython():
+            elif CONFIG["shell"] == "ipython_kernel" and shell.have_ipython():
                 runner = shell.run_ipython_kernel
             elif CONFIG["shell"] == "bpython" and shell.HAVE_BPYTHON:
                 runner = shell.run_bpython_shell

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1920,6 +1920,8 @@ class DebuggerUI(FrameVarInfoKeeper):
             import pudb.shell as shell
             if CONFIG["shell"] == "ipython" and shell.have_ipython():
                 runner = shell.run_ipython_shell
+            if CONFIG["shell"] == "ipython-kernel" and shell.have_ipython():
+                runner = shell.run_ipython_kernel
             elif CONFIG["shell"] == "bpython" and shell.HAVE_BPYTHON:
                 runner = shell.run_bpython_shell
             elif CONFIG["shell"] == "ptpython" and shell.HAVE_PTPYTHON:

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1920,7 +1920,7 @@ class DebuggerUI(FrameVarInfoKeeper):
             import pudb.shell as shell
             if CONFIG["shell"] == "ipython" and shell.have_ipython():
                 runner = shell.run_ipython_shell
-            if CONFIG["shell"] == "ipython-kernel" and shell.have_ipython():
+            elif CONFIG["shell"] == "ipython-kernel" and shell.have_ipython():
                 runner = shell.run_ipython_kernel
             elif CONFIG["shell"] == "bpython" and shell.HAVE_BPYTHON:
                 runner = shell.run_bpython_shell

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -272,7 +272,7 @@ def edit_config(ui, conf_dict):
 
     shell_info = urwid.Text("This is the shell that will be "
             "used when you hit '!'.\n")
-    shells = ["internal", "classic", "ipython", "ipython-kernel", "bpython",
+    shells = ["internal", "classic", "ipython", "ipython_kernel", "bpython",
               "ptpython", "ptipython"]
     known_shell = conf_dict["shell"] in shells
     shell_edit = urwid.Edit(edit_text=conf_dict["custom_shell"])

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -272,7 +272,8 @@ def edit_config(ui, conf_dict):
 
     shell_info = urwid.Text("This is the shell that will be "
             "used when you hit '!'.\n")
-    shells = ["internal", "classic", "ipython", "ipython-kernel", "bpython", "ptpython", "ptipython"]
+    shells = ["internal", "classic", "ipython", "ipython-kernel", "bpython",
+              "ptpython", "ptipython"]
     known_shell = conf_dict["shell"] in shells
     shell_edit = urwid.Edit(edit_text=conf_dict["custom_shell"])
     shell_edit_list_item = urwid.AttrMap(shell_edit, "value")

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -272,7 +272,7 @@ def edit_config(ui, conf_dict):
 
     shell_info = urwid.Text("This is the shell that will be "
             "used when you hit '!'.\n")
-    shells = ["internal", "classic", "ipython", "bpython", "ptpython", "ptipython"]
+    shells = ["internal", "classic", "ipython", "ipython-kernel", "bpython", "ptpython", "ptipython"]
     known_shell = conf_dict["shell"] in shells
     shell_edit = urwid.Edit(edit_text=conf_dict["custom_shell"])
     shell_edit_list_item = urwid.AttrMap(shell_edit, "value")

--- a/pudb/shell.py
+++ b/pudb/shell.py
@@ -231,6 +231,17 @@ def run_ipython_shell(globals, locals):
     else:
         return run_ipython_shell_v11(globals, locals)
 
+
+def run_ipython_kernel(globals, locals):
+    from IPython import embed_kernel
+
+    class DummyMod(object):
+        pass
+
+    user_module = DummyMod()
+    user_module.__dict__ = globals
+    embed_kernel(module=user_module, local_ns=locals)
+
 # }}}
 
 


### PR DESCRIPTION
This PR adds support of `ipython-kernel` as a shell candidate. When called, it launches an `ipython` kernel, which can be connected to using `qtconsole` by
```
ipython qtconsole --existing
```

In `qtconsole`, plots stick around as a part of the scrollback history, which can be exported easily as HTML. This makes a bit better experience when inspecting multiple plots.