### PR TITLE
Add a theme style for current line column

### DIFF
--- a/pudb/source_view.py
+++ b/pudb/source_view.py
@@ -105,7 +105,7 @@ class SourceLine(urwid.FlowWidget):
             line_prefix = self.line_nr
 
         line_prefix = crnt+bp+line_prefix
-        line_prefix_attr = [("line marker", 1),
+        line_prefix_attr = [("current line marker", 1),
                             ("breakpoint marker", 1)] \
                 + line_prefix_attr
 

--- a/pudb/source_view.py
+++ b/pudb/source_view.py
@@ -105,7 +105,8 @@ class SourceLine(urwid.FlowWidget):
             line_prefix = self.line_nr
 
         line_prefix = crnt+bp+line_prefix
-        line_prefix_attr = [("source", 1), ("breakpoint marker", 1)] \
+        line_prefix_attr = [("line marker", 1),
+                            ("breakpoint marker", 1)] \
                 + line_prefix_attr
 
         # assume rendered width is same as len

--- a/pudb/theme.py
+++ b/pudb/theme.py
@@ -69,17 +69,17 @@ def get_palette(may_use_fancy_formats, theme="classic"):
     # ------------------------------------------------------------------------------
 
     inheritance_map = (
-        # Style         Inherits from
-        # ----------    ----------
-        ("namespace",   "keyword"),
-        ("operator",    "source"),
-        ("argument",    "source"),
-        ("builtin",     "source"),
-        ("pseudo",      "source"),
-        ("dunder",      "name"),
-        ("exception",   "source"),
-        ("keyword2",    "keyword"),
-        ("line marker", "source"),
+        # Style                 Inherits from
+        # ----------            ----------
+        ("namespace",           "keyword"),
+        ("operator",            "source"),
+        ("argument",            "source"),
+        ("builtin",             "source"),
+        ("pseudo",              "source"),
+        ("dunder",              "name"),
+        ("exception",           "source"),
+        ("keyword2",            "keyword"),
+        ("current line marker", "source"),
     )
 
     palette_dict = {
@@ -167,7 +167,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
 
         # {{{ highlighting
 
-        "line marker": ("dark red", "dark blue"),
+        "current line marker": ("dark red", "dark blue"),
         "breakpoint marker": ("dark red", "dark blue"),
         "line number": ("light gray", "dark blue"),
         "keyword": (add_setting("white", "bold"), "dark blue"),
@@ -262,7 +262,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "classname": ("dark cyan", "default"),
             "name": ("dark cyan", "default"),
             "line number": ("dark gray", "default"),
-            "line marker": ("dark red", "default"),
+            "current line marker": ("dark red", "default"),
             "breakpoint marker": ("dark red", "default"),
 
             # {{{ shell
@@ -380,7 +380,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
 
             # {{{ source view
 
-            "line marker": ("dark red", "black"),
+            "current line marker": ("dark red", "black"),
             "breakpoint marker": ("dark red", "black"),
 
             "breakpoint source": ("light gray", "dark red"),
@@ -502,7 +502,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "classname": ("dark cyan", "default"),
             "funcname": ("white", "default"),
 
-            "line marker": ("dark red", "default"),
+            "current line marker": ("dark red", "default"),
             "breakpoint marker": ("dark red", "default"),
 
             # {{{ shell
@@ -586,7 +586,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "current breakpoint source": ("black", "light green"),
             "breakpoint focused source": ("dark gray", "dark blue"),
             "current breakpoint focused source": ("black", "light green"),
-            "line marker": ("dark red", "default"),
+            "current line marker": ("dark red", "default"),
             "breakpoint marker": ("dark red", "default"),
 
             "search box": ("default", "default"),
@@ -714,7 +714,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             # }}}
 
             # {{{ source view
-            "line marker": ("h160", "h235"),
+            "current line marker": ("h160", "h235"),
             "breakpoint marker": ("h160", "h235"),
 
             "breakpoint source": ("h252", "h124"),
@@ -837,7 +837,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "classname": ("dark cyan", "default"),
             "funcname": ("white", "default"),
 
-            "line marker": ("dark red", "default"),
+            "current line marker": ("dark red", "default"),
             "breakpoint marker": ("dark red", "default"),
 
             # {{{ shell
@@ -945,7 +945,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             # }}}
 
             # {{{ source view
-            "line marker": ("h160", "h235"),
+            "current line marker": ("h160", "h235"),
             "breakpoint marker": ("h160", "h235"),
 
             "breakpoint source": ("h252", "h124"),

--- a/pudb/theme.py
+++ b/pudb/theme.py
@@ -69,16 +69,17 @@ def get_palette(may_use_fancy_formats, theme="classic"):
     # ------------------------------------------------------------------------------
 
     inheritance_map = (
-        # Style       Inherits from
-        # ----------  ----------
-        ("namespace", "keyword"),
-        ("operator",  "source"),
-        ("argument",  "source"),
-        ("builtin",   "source"),
-        ("pseudo",    "source"),
-        ("dunder",    "name"),
-        ("exception", "source"),
-        ("keyword2",  "keyword")
+        # Style         Inherits from
+        # ----------    ----------
+        ("namespace",   "keyword"),
+        ("operator",    "source"),
+        ("argument",    "source"),
+        ("builtin",     "source"),
+        ("pseudo",      "source"),
+        ("dunder",      "name"),
+        ("exception",   "source"),
+        ("keyword2",    "keyword"),
+        ("line marker", "source"),
     )
 
     palette_dict = {
@@ -166,6 +167,8 @@ def get_palette(may_use_fancy_formats, theme="classic"):
 
         # {{{ highlighting
 
+        "line marker": ("dark red", "dark blue"),
+        "breakpoint marker": ("dark red", "dark blue"),
         "line number": ("light gray", "dark blue"),
         "keyword": (add_setting("white", "bold"), "dark blue"),
         "name": ("light cyan", "dark blue"),
@@ -184,8 +187,6 @@ def get_palette(may_use_fancy_formats, theme="classic"):
         # }}}
 
         # {{{ breakpoints
-
-        "breakpoint marker": ("dark red", "dark blue"),
 
         "breakpoint source": (add_setting("yellow", "bold"), "dark red"),
         "breakpoint focused source": ("black", "dark red"),
@@ -261,6 +262,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "classname": ("dark cyan", "default"),
             "name": ("dark cyan", "default"),
             "line number": ("dark gray", "default"),
+            "line marker": ("dark red", "default"),
             "breakpoint marker": ("dark red", "default"),
 
             # {{{ shell
@@ -378,6 +380,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
 
             # {{{ source view
 
+            "line marker": ("dark red", "black"),
             "breakpoint marker": ("dark red", "black"),
 
             "breakpoint source": ("light gray", "dark red"),
@@ -499,6 +502,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "classname": ("dark cyan", "default"),
             "funcname": ("white", "default"),
 
+            "line marker": ("dark red", "default"),
             "breakpoint marker": ("dark red", "default"),
 
             # {{{ shell
@@ -582,6 +586,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "current breakpoint source": ("black", "light green"),
             "breakpoint focused source": ("dark gray", "dark blue"),
             "current breakpoint focused source": ("black", "light green"),
+            "line marker": ("dark red", "default"),
             "breakpoint marker": ("dark red", "default"),
 
             "search box": ("default", "default"),
@@ -709,6 +714,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             # }}}
 
             # {{{ source view
+            "line marker": ("h160", "h235"),
             "breakpoint marker": ("h160", "h235"),
 
             "breakpoint source": ("h252", "h124"),
@@ -831,6 +837,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             "classname": ("dark cyan", "default"),
             "funcname": ("white", "default"),
 
+            "line marker": ("dark red", "default"),
             "breakpoint marker": ("dark red", "default"),
 
             # {{{ shell
@@ -938,6 +945,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
             # }}}
 
             # {{{ source view
+            "line marker": ("h160", "h235"),
             "breakpoint marker": ("h160", "h235"),
 
             "breakpoint source": ("h252", "h124"),


### PR DESCRIPTION
I like to use a different background for the line number column, then again for the sign column in vim. It was almost possible to replicate this in pudb before, the only thing missing was that the column for the ">" current line marker didn't have its own style setting available. Now it does!

I made sure to go back and include it in all the previously existing themes, and I quickly tried them out and they seemed to work. What do you think of the name of the style, is it clear enough?