### PR TITLE
Clean up some render issues with long vars/values in the var_view

### DIFF
--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -145,9 +145,11 @@ class VariableWidget(urwid.FlowWidget):
     def selectable(self):
         return True
 
-    SIZE_LIMIT = 20
-
-    def _get_text(self, size):
+    def _get_wrapped_lines(self, size):
+        """
+        :return: list of string lines, including prefixes, wrapped to fit in
+        the available space,
+        """
         maxcol = size[0] - len(self.prefix)  # self.prefix is a padding
         var_label = self.var_label or ""
         value_str = self.value_str or ""
@@ -163,11 +165,9 @@ class VariableWidget(urwid.FlowWidget):
 
     def rows(self, size, focus=False):
         if self.wrap:
-            return len(self._get_text(size))
+            return len(self._get_wrapped_lines(size))
 
-        if (self.value_str is not None
-                and self.var_label is not None
-                and len(self.prefix) + text_width(self.var_label) > self.SIZE_LIMIT):
+        if len(self._get_wrapped_lines(size)) > 1:
             return 2
         else:
             return 1
@@ -184,7 +184,7 @@ class VariableWidget(urwid.FlowWidget):
         var_label = self.var_label or ""
 
         if self.wrap:
-            text = self._get_text(size)
+            text = self._get_wrapped_lines(size)
 
             extralabel_full, extralabel_rem = divmod(
                     text_width(var_label[maxcol:]), maxcol)
@@ -214,7 +214,7 @@ class VariableWidget(urwid.FlowWidget):
 
         if self.value_str is not None:
             if self.var_label is not None:
-                if len(self.prefix) + text_width(self.var_label) > self.SIZE_LIMIT:
+                if len(self._get_wrapped_lines(size)) > 1:
                     # label too long? generate separate value line
                     text = [self.prefix + self.var_label + ":",
                             self.prefix+"  " + self.value_str]

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -159,7 +159,7 @@ class VariableWidget(urwid.FlowWidget):
         fulllines, rest = divmod(text_width(alltext) - maxcol, maxcol - 2)
         restlines = [alltext[(maxcol - 2)*i + maxcol:(maxcol - 2)*i + 2*maxcol - 2]
             for i in xrange(fulllines + bool(rest))]
-        return [firstline] + ["  " + self.prefix + i for i in restlines]
+        return [firstline] + [self.prefix + "  " + i for i in restlines]
 
     def rows(self, size, focus=False):
         if self.wrap:

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -216,11 +216,11 @@ class VariableWidget(urwid.FlowWidget):
             if self.var_label is not None:
                 if len(self.prefix) + text_width(self.var_label) > self.SIZE_LIMIT:
                     # label too long? generate separate value line
-                    text = [self.prefix + self.var_label,
+                    text = [self.prefix + self.var_label + ":",
                             self.prefix+"  " + self.value_str]
 
                     attr = [
-                        [(apfx+"label", lprefix+text_width(self.var_label))],
+                        [(apfx+"label", lprefix+text_width(self.var_label) + 1)],
                         [(apfx+"value", lprefix+2+text_width(self.value_str))]
                         ]
                 else:

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -33,6 +33,7 @@ THE SOFTWARE.
 import urwid
 import inspect
 
+from typing import Tuple, List
 from pudb.lowlevel import ui_log
 
 try:
@@ -145,10 +146,11 @@ class VariableWidget(urwid.FlowWidget):
     def selectable(self):
         return True
 
-    def _get_wrapped_lines(self, maxcol):
+    def _get_wrapped_lines(self, maxcol: int) -> List[str]:
         """
+        :param maxcol: the number of columns available to this widget
         :return: list of string lines, including prefixes, wrapped to fit in
-            the available space,
+            the available space
         """
         maxcol -= len(self.prefix)  # self.prefix is padding
         var_label = self.var_label or ""
@@ -163,7 +165,12 @@ class VariableWidget(urwid.FlowWidget):
             for i in xrange(fulllines + bool(rest))]
         return [firstline] + [self.prefix + "  " + i for i in restlines]
 
-    def rows(self, size, focus=False):
+    def rows(self, size: Tuple[int], focus: bool = False) -> int:
+        """
+        :param size: (maxcol,) the number of columns available to this widget
+        :param focus: True if this widget or one of its children is in focus
+        :return: The number of rows required for this widget
+        """
         if self.wrap:
             return len(self._get_wrapped_lines(size[0]))
 
@@ -172,7 +179,13 @@ class VariableWidget(urwid.FlowWidget):
         else:
             return 1
 
-    def render(self, size, focus=False):
+    def render(self, size: Tuple[int], focus: bool = False) -> urwid.Canvas:
+        """
+        :param size: (maxcol,) the number of columns available to this widget
+        :param focus: True if this widget or one of its children is in focus
+        :return: A Canvas subclass instance containing the rendered content of
+            this widget
+        """
         from pudb.ui_tools import make_canvas
 
         maxcol = size[0]

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -148,9 +148,9 @@ class VariableWidget(urwid.FlowWidget):
     def _get_wrapped_lines(self, size):
         """
         :return: list of string lines, including prefixes, wrapped to fit in
-        the available space,
+            the available space,
         """
-        maxcol = size[0] - len(self.prefix)  # self.prefix is a padding
+        maxcol = size[0] - len(self.prefix)  # self.prefix is padding
         var_label = self.var_label or ""
         value_str = self.value_str or ""
         alltext = var_label + ": " + value_str

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -145,12 +145,12 @@ class VariableWidget(urwid.FlowWidget):
     def selectable(self):
         return True
 
-    def _get_wrapped_lines(self, size):
+    def _get_wrapped_lines(self, maxcol):
         """
         :return: list of string lines, including prefixes, wrapped to fit in
             the available space,
         """
-        maxcol = size[0] - len(self.prefix)  # self.prefix is padding
+        maxcol -= len(self.prefix)  # self.prefix is padding
         var_label = self.var_label or ""
         value_str = self.value_str or ""
         alltext = var_label + ": " + value_str
@@ -165,9 +165,9 @@ class VariableWidget(urwid.FlowWidget):
 
     def rows(self, size, focus=False):
         if self.wrap:
-            return len(self._get_wrapped_lines(size))
+            return len(self._get_wrapped_lines(size[0]))
 
-        if len(self._get_wrapped_lines(size)) > 1:
+        if len(self._get_wrapped_lines(size[0])) > 1:
             return 2
         else:
             return 1
@@ -184,7 +184,7 @@ class VariableWidget(urwid.FlowWidget):
         var_label = self.var_label or ""
 
         if self.wrap:
-            text = self._get_wrapped_lines(size)
+            text = self._get_wrapped_lines(maxcol)
 
             extralabel_full, extralabel_rem = divmod(
                     text_width(var_label[maxcol:]), maxcol)
@@ -214,7 +214,7 @@ class VariableWidget(urwid.FlowWidget):
 
         if self.value_str is not None:
             if self.var_label is not None:
-                if len(self._get_wrapped_lines(size)) > 1:
+                if len(self._get_wrapped_lines(maxcol)) > 1:
                     # label too long? generate separate value line
                     text = [self.prefix + self.var_label + ":",
                             self.prefix+"  " + self.value_str]


### PR DESCRIPTION
This PR just deals with some pretty minor things in the way the var_view renders variables with long names and/or values.

If you have a really long variable/value combo in the var view and you don't wrap, the value is printed on a subsequent line, e.g.
```
| | .my_long_named_attribute
| |   [0, 1, 2, 3, 4, 5]
```
If you were to wrap the same variable it might be rendered as:
```
| | .my_long_named_attribute: [0, 1,
  | | 2, 3, 4, 5]
```
---
This PR normalizes the two by making the non-wrapped one look like this: (note the ":" on the first line)
```
| | .my_long_named_attribute:
| |   [0, 1, 2, 3, 4, 5]
```
And the wrapped one look like this: (note the spaces on the second line now come after the prefix)
```
| | .my_long_named_attribute: [0, 1,
| |   2, 3, 4, 5]
```
There's also a tweak to make sure that when not wrapping, we'll only use two lines for a variable if we actually don't have enough space to show it in one.