### PR TITLE
Do not accidentally repeat similar variable names at top

### DIFF
--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -562,10 +562,10 @@ class TopAndMainVariableWalker(ValueWalker):
 
         # Perhaps it's a child of the top-level path
         before, sep, after = id_path.partition(tipp)
-        return (before == "" and
-                sep == tipp and
-                len(after) > 0 and
-                after[0] in ".<[")
+        return (before == ""
+                and sep == tipp
+                and len(after) > 0
+                and after[0] in ".<[")
 
     def add_item(self, parent, var_label, value_str, id_path=None, attr_prefix=None):
         iinfo = self.frame_var_info.get_inspect_info(id_path, read_only=True)

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -550,6 +550,23 @@ class TopAndMainVariableWalker(ValueWalker):
 
         self.top_id_path_prefixes = []
 
+    @staticmethod
+    def _should_repeat_at_top(id_path, tipp) -> bool:
+        """
+        :return: True if the id_path is a child path of tipp
+        """
+        if id_path is None:
+            return False
+        if id_path == tipp:
+            return True
+
+        # Perhaps it's a child of the top-level path
+        before, sep, after = id_path.partition(tipp)
+        return (before == "" and
+                sep == tipp and
+                len(after) > 0 and
+                after[0] in ".<[")
+
     def add_item(self, parent, var_label, value_str, id_path=None, attr_prefix=None):
         iinfo = self.frame_var_info.get_inspect_info(id_path, read_only=True)
         if iinfo.highlighted:
@@ -560,7 +577,7 @@ class TopAndMainVariableWalker(ValueWalker):
             self.top_id_path_prefixes.append(id_path)
 
         for tipp in self.top_id_path_prefixes:
-            if id_path is not None and id_path.startswith(tipp):
+            if self._should_repeat_at_top(id_path, tipp):
                 repeated_at_top = True
 
         if repeated_at_top:


### PR DESCRIPTION
This fixes a bug where if you have a variable 'foo' and another variable 'foobar', and use the '@' command to repeat 'foo' at the top of the variable list, 'foobar' would also get repeated.