### PR TITLE
Add a built-in stringifier to display the object's id()

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -112,7 +112,7 @@ Keys in variables list:
     \/enter/space - expand/collapse
     h - collapse
     l - expand
-    t/r/s/c - show type/repr/str/custom for this variable
+    t/r/s/i/c - show type/repr/str/id/custom for this variable
     H - toggle highlighting
     @ - toggle repetition at top
     * - cycle attribute visibility: public/_private/__dunder__
@@ -922,6 +922,8 @@ class DebuggerUI(FrameVarInfoKeeper):
                 iinfo.display_type = "repr"
             elif key == "s":
                 iinfo.display_type = "str"
+            elif key == "i":
+                iinfo.display_type = "id"
             elif key == "c":
                 iinfo.display_type = CONFIG["custom_stringifier"]
             elif key == "H":
@@ -976,6 +978,8 @@ class DebuggerUI(FrameVarInfoKeeper):
                     iinfo.display_type == "repr")
             rb_show_str = urwid.RadioButton(rb_grp_show, "Show str()",
                     iinfo.display_type == "str")
+            rb_show_id = urwid.RadioButton(rb_grp_show, "Show id()",
+                    iinfo.display_type == "id")
             rb_show_custom = urwid.RadioButton(
                     rb_grp_show, "Show custom (set in prefs)",
                     iinfo.display_type == CONFIG["custom_stringifier"])
@@ -1025,6 +1029,8 @@ class DebuggerUI(FrameVarInfoKeeper):
                     iinfo.display_type = "repr"
                 elif rb_show_str.get_state():
                     iinfo.display_type = "str"
+                elif rb_show_id.get_state():
+                    iinfo.display_type = "id"
                 elif rb_show_custom.get_state():
                     iinfo.display_type = CONFIG["custom_stringifier"]
 
@@ -1072,6 +1078,7 @@ class DebuggerUI(FrameVarInfoKeeper):
         self.var_list.listen("t", change_var_state)
         self.var_list.listen("r", change_var_state)
         self.var_list.listen("s", change_var_state)
+        self.var_list.listen("i", change_var_state)
         self.var_list.listen("c", change_var_state)
         self.var_list.listen("H", change_var_state)
         self.var_list.listen("@", change_var_state)

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -342,7 +342,7 @@ def edit_config(ui, conf_dict):
 
     # {{{ stringifier
 
-    stringifier_opts = ["type", "str", "repr"]
+    stringifier_opts = ["type", "str", "repr", "id"]
     known_stringifier = conf_dict["stringifier"] in stringifier_opts
     stringifier_rb_group = []
     stringifier_edit = urwid.Edit(edit_text=conf_dict["custom_stringifier"])

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -322,7 +322,7 @@ def type_stringifier(value):
 
 
 def id_stringifier(obj):
-    return '{id:#x}'.format(id=id(obj))
+    return "{id:#x}".format(id=id(obj))
 
 
 def error_stringifier(_):

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -325,6 +325,10 @@ def id_stringifier(obj):
     return '{id:#x}'.format(id=id(obj))
 
 
+def error_stringifier(_):
+    return "ERROR: Invalid custom stringifier file."
+
+
 def get_stringifier(iinfo):
     """Return a function that turns an object into a Unicode text object."""
 
@@ -342,11 +346,8 @@ def get_stringifier(iinfo):
                 from os.path import expanduser
                 execfile(expanduser(iinfo.display_type), custom_stringifier_dict)
         except Exception:
-            print("Error when importing custom stringifier:")
-            from traceback import print_exc
-            print_exc()
-            raw_input("Hit enter:")
-            return lambda value: text_type("ERROR: Invalid custom stringifier file.")
+            ui_log.exception("Error when importing custom stringifier")
+            return error_stringifier
         else:
             if "pudb_stringifier" not in custom_stringifier_dict:
                 print("%s does not contain a function named pudb_stringifier at "

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -321,6 +321,10 @@ def type_stringifier(value):
     return text_type(type(value).__name__)
 
 
+def id_stringifier(obj):
+    return '{id:#x}'.format(id=id(obj))
+
+
 def get_stringifier(iinfo):
     """Return a function that turns an object into a Unicode text object."""
 
@@ -330,6 +334,8 @@ def get_stringifier(iinfo):
         return repr
     elif iinfo.display_type == "str":
         return str
+    elif iinfo.display_type == "id":
+        return id_stringifier
     else:
         try:
             if not custom_stringifier_dict:  # Only execfile once

--- a/test/test_var_view.py
+++ b/test/test_var_view.py
@@ -24,7 +24,7 @@ def test_get_stringifier():
             A, A2, A(), A2(), u"lól".encode("utf8"), u"lól",
             1233123, [u"lól".encode("utf8"), u"lól"],
             ] + numpy_values:
-        for display_type in ["type", "repr", "str"]:
+        for display_type in ["type", "repr", "str", "id"]:
             iinfo = InspectInfo()
             iinfo.display_type = display_type
 


### PR DESCRIPTION
I've been using this as a custom stringifier for a while, but I think it is useful and generic enough to warrant inclusion as a built-in.

Use cases typically involve quickly checking whether or not two "equal" variables point to the same object.

Thoughts? I think I hooked this up in all the right places. I've also thrown in a change to use the new `ui_log` to print errors when trying to run the custom stringifier, since currently the message mucks with the rendering of the debugger.