### PR TITLE
Open file to edit from debugger

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1145,7 +1145,6 @@ class DebuggerUI(FrameVarInfoKeeper):
             file_name = curframe.f_code.co_filename
 
             open_file_editor(file_name, line_number)
-            redraw_screen(w, size, key)
 
         self.stack_list.listen("ctrl e", open_editor_on_stack_frame)
 

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -346,16 +346,11 @@ class Debugger(bdb.Bdb):
         self.curframe, line_number = self.stack[index]
         filename = self.curframe.f_code.co_filename
 
+        if not line_number:
+            line_number = 1
+
         editor = os.environ.get("EDITOR", "nano")
-        editor = editor.lower()
-
-        editor_command = f"{editor}"
-        if editor in {"vi", "vim", "nvim", "emacs"}:
-            editor_command = f"{editor} +{line_number}"
-        elif editor == "nano":
-            editor_command = f"{editor} -l {line_number}"
-
-        command_to_run = f"{editor_command} {filename}"
+        command_to_run = f"{editor} +{line_number} {filename}"
         os.system(command=command_to_run)
 
     def move_up_frame(self):

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1133,8 +1133,7 @@ class DebuggerUI(FrameVarInfoKeeper):
             except Exception:
                 from pudb.lowlevel import format_exception
                 self.message("Exception happened when trying to edit the file:"
-                             "\n\n%s" % (
-                    "".join(format_exception(sys.exc_info()))),
+                             "\n\n%s" % ("".join(format_exception(sys.exc_info()))),
                     title="File Edit Error")
                 return
 

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -344,7 +344,8 @@ class Debugger(bdb.Bdb):
 
         self.ui.stack_list._w.set_focus(self.ui.translate_ui_stack_index(index))
 
-    def open_file_to_edit(self, filename, line_number):
+    @staticmethod
+    def open_file_to_edit(filename, line_number):
 
         if not filename:
             raise ValueError("Could not get filename as it was None")

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -360,6 +360,8 @@ class Debugger(bdb.Bdb):
         import subprocess
         subprocess.call([editor, f"+{line_number}", filename], shell=False)
 
+        return filename
+
     def move_up_frame(self):
         if self.curindex > 0:
             self.set_frame_index(self.curindex-1)
@@ -1126,13 +1128,18 @@ class DebuggerUI(FrameVarInfoKeeper):
             index = self.translate_ui_stack_index(pos)
 
             try:
-                self.debugger.open_file_to_edit(index)
+                filename_edited = self.debugger.open_file_to_edit(index)
             except Exception:
                 from pudb.lowlevel import format_exception
                 self.message("Exception happened when trying to edit the file: \n\n%s" % (
                     "".join(format_exception(sys.exc_info()))),
                     title="File Edit Error")
+                return
 
+            self.message("File is changed, but the execution is continued with the 'old' codebase.\n"
+                         f"Changed file: {filename_edited}\n"
+                         "Please quit and restart to see changes",
+                         title="File is changed")
             redraw_screen(w, size, key)
 
         self.stack_list.listen("ctrl e", open_editor_on_frame)

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -123,6 +123,7 @@ Keys in variables list:
 
 Keys in stack list:
     enter - jump to frame
+    Ctrl-e - open file at line to edit with $EDITOR
 
 Keys in breakpoints list:
     enter - jump to breakpoint

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -2049,7 +2049,6 @@ class DebuggerUI(FrameVarInfoKeeper):
             file_name = self.debugger.curframe.f_code.co_filename
             line_number = self.debugger.curframe.f_lineno
             open_file_editor(file_name, line_number)
-            redraw_screen(w, size, key)
 
         self.top.listen("o", show_output)
         self.top.listen("ctrl r", reload_breakpoints)

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1125,7 +1125,8 @@ class DebuggerUI(FrameVarInfoKeeper):
 
         def open_file_editor(file_name, line_number):
             try:
-                filename_edited = self.debugger.open_file_to_edit(file_name, line_number)
+                filename_edited = self.debugger.open_file_to_edit(file_name,
+                                                                  line_number)
             except Exception:
                 from pudb.lowlevel import format_exception
                 self.message("Exception happened when trying to edit the file:"

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -2406,7 +2406,7 @@ class DebuggerUI(FrameVarInfoKeeper):
                 self.message("Package 'pygments' not found. "
                         "Syntax highlighting disabled.")
 
-        WELCOME_LEVEL = "e037"  # noqa
+        WELCOME_LEVEL = "e039"  # noqa
         if CONFIG["seen_welcome"] < WELCOME_LEVEL:
             CONFIG["seen_welcome"] = WELCOME_LEVEL
             from pudb import VERSION
@@ -2422,6 +2422,13 @@ class DebuggerUI(FrameVarInfoKeeper):
                     "If you're new here, welcome! The help screen "
                     "(invoked by hitting '?' after this message) should get you "
                     "on your way.\n"
+
+                    "\nChanges in version 2021.1:\n\n"
+                    "- Add shortcut to edit files in source and stack view "
+                    "(Gábor Vecsei)\n"
+                    "- Major improvements to the variable view "
+                    "(Michael van der Kamp)\n"
+                    "- Better internal error reporting (Michael van der Kamp)\n"
 
                     "\nChanges in version 2020.1:\n\n"
                     "- Add vi keys for the sidebar (Asbjørn Apeland)\n"

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -350,7 +350,7 @@ class Debugger(bdb.Bdb):
         editor = editor.lower()
 
         editor_command = f"{editor}"
-        if editor in {"vi", "vim", "nvim"}:
+        if editor in {"vi", "vim", "nvim", "emacs"}:
             editor_command = f"{editor} +{line_number}"
         elif editor == "nano":
             editor_command = f"{editor} -l {line_number}"

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -356,8 +356,9 @@ class Debugger(bdb.Bdb):
             line_number = 1
 
         editor = os.environ.get("EDITOR", "nano")
-        command_to_run = f"{editor} +{line_number} {filename}"
-        os.system(command=command_to_run)
+
+        import subprocess
+        subprocess.call([editor, f"+{line_number}", filename], shell=False)
 
     def move_up_frame(self):
         if self.curindex > 0:

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -346,10 +346,6 @@ class Debugger(bdb.Bdb):
 
     @staticmethod
     def open_file_to_edit(filename, line_number):
-
-        if not filename:
-            raise ValueError("Could not get filename as it was None")
-
         if not os.path.isfile(filename):
             raise FileNotFoundError(f"Could not find the file with name: {filename}")
 

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -348,7 +348,7 @@ class Debugger(bdb.Bdb):
         filename = self.curframe.f_code.co_filename
 
         if not filename:
-            raise ValueError(f"Could not get filename as it was None")
+            raise ValueError("Could not get filename as it was None")
 
         if not os.path.isfile(filename):
             raise FileNotFoundError(f"Could not find the file with name: {filename}")
@@ -1132,13 +1132,15 @@ class DebuggerUI(FrameVarInfoKeeper):
                 filename_edited = self.debugger.open_file_to_edit(index)
             except Exception:
                 from pudb.lowlevel import format_exception
-                self.message("Exception happened when trying to edit the file: \n\n%s" % (
+                self.message("Exception happened when trying to edit the file:"
+                             "\n\n%s" % (
                     "".join(format_exception(sys.exc_info()))),
                     title="File Edit Error")
                 return
 
-            self.message("File is changed, but the execution is continued with the 'old' codebase.\n"
-                         f"Changed file: {filename_edited}\n"
+            self.message("File is changed, but the execution is continued with"
+                         " the 'old' codebase.\n"
+                         f"Changed file: {filename_edited}\n\n"
                          "Please quit and restart to see changes",
                          title="File is changed")
             redraw_screen(w, size, key)

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -622,7 +622,7 @@ class NullSourceCodeProvider(SourceCodeProvider):
     def identifier(self):
         return "<no source code>"
 
-    def get_breakpoint_source_identifier(self):
+    def get_source_identifier(self):
         return None
 
     def clear_cache(self):
@@ -658,7 +658,7 @@ class FileSourceCodeProvider(SourceCodeProvider):
     def identifier(self):
         return self.file_name
 
-    def get_breakpoint_source_identifier(self):
+    def get_source_identifier(self):
         return self.file_name
 
     def clear_cache(self):
@@ -705,7 +705,7 @@ class DirectSourceCodeProvider(SourceCodeProvider):
     def identifier(self):
         return "<source code of function %s>" % self.function_name
 
-    def get_breakpoint_source_identifier(self):
+    def get_source_identifier(self):
         return None
 
     def clear_cache(self):
@@ -1181,7 +1181,7 @@ class DebuggerUI(FrameVarInfoKeeper):
 
         def delete_breakpoint(w, size, key):
             bp_source_identifier = \
-                    self.source_code_provider.get_breakpoint_source_identifier()
+                    self.source_code_provider.get_source_identifier()
 
             if bp_source_identifier is None:
                 self.message(
@@ -1270,7 +1270,7 @@ class DebuggerUI(FrameVarInfoKeeper):
                 self.columns.set_focus(0)
             elif result == "del":
                 bp_source_identifier = \
-                        self.source_code_provider.get_breakpoint_source_identifier()
+                        self.source_code_provider.get_source_identifier()
 
                 if bp_source_identifier is None:
                     self.message(
@@ -1349,7 +1349,7 @@ class DebuggerUI(FrameVarInfoKeeper):
                 lineno = pos+1
 
                 bp_source_identifier = \
-                        self.source_code_provider.get_breakpoint_source_identifier()
+                        self.source_code_provider.get_source_identifier()
 
                 if bp_source_identifier is None:
                     self.message(
@@ -1419,7 +1419,7 @@ class DebuggerUI(FrameVarInfoKeeper):
 
         def toggle_breakpoint(w, size, key):
             bp_source_identifier = \
-                    self.source_code_provider.get_breakpoint_source_identifier()
+                    self.source_code_provider.get_source_identifier()
 
             if bp_source_identifier:
                 sline, pos = self.source.get_focus()
@@ -2059,9 +2059,16 @@ class DebuggerUI(FrameVarInfoKeeper):
             self.message(pages, title="PuDB - The Python Urwid Debugger")
 
         def edit_current_frame(w, size, key):
-            file_name = self.debugger.curframe.f_code.co_filename
-            line_number = self.debugger.curframe.f_lineno
-            open_file_editor(file_name, line_number)
+            _, pos = self.source.get_focus()
+            source_identifier = \
+                    self.source_code_provider.get_source_identifier()
+
+            if source_identifier is None:
+                self.message(
+                    "Cannot edit the current file--"
+                    "source code does not correspond to a file location. "
+                    "(perhaps this is generated code)")
+            open_file_editor(source_identifier, pos+1)
 
         self.top.listen("o", show_output)
         self.top.listen("ctrl r", reload_breakpoints)


### PR DESCRIPTION
Issue: #211 

## Feature

When you are on a file at the "stack" window, you can press `Ctrl+e` and the file will open with your editor, based on the `$EDITOR` environment variable. When you are done with editing you can just save and quit the file, and you will be returned to the debugger.

`reload()` is not used (because of this comment: https://github.com/inducer/pudb/issues/211#issuecomment-327031721), so the edits won't be noticable immediately, only after quitting the debugger and starting it again