### PR TITLE
Add more project links

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,9 @@
+[metadata]
+project_urls =
+    Homepage=https://documen.tician.de/pudb/
+    Source=https://github.com/inducer/pudb
+    Tracker=https://github.com/inducer/pudb/issues
+
 [flake8]
 ignore = E126,E127,E128,E123,E226,E241,E242,E265,W503,E402
 max-line-length=85

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
     test_requires=[
         "pytest>=2",
     ],
-    url="https://github.com/inducer/pudb",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",


### PR DESCRIPTION
Currently the pudb pypi page https://pypi.org/project/pudb/ only has one link in the "Project links" list. The link is titled "Homepage" and points to https://github.com/inducer/pudb.

This PR should (in theory) change the list to the following:
```
    Homepage=https://documen.tician.de/pudb/
    Source=https://github.com/inducer/pudb
    Tracker=https://github.com/inducer/pudb/issues
```