### PR TITLE
Add jedi dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     install_requires=[
         "urwid>=1.1.1",
         "pygments>=1.0",
+        "jedi>=0.18,<1"
     ],
     test_requires=[
         "pytest>=2",


### PR DESCRIPTION
Fixes https://github.com/inducer/pudb/issues/414

pudb needs jedi for tab completion, but it was not listed as a
dependency. This PR adds the missing dependency.

I'm not sure which version of jedi to depend on. Is there any reason
not to depend on the latest version (currently 0.18)?

I have added the <1 constraint to guard against potential future
breaking changes in jedi