### PR TITLE
Fix reload_breakpoints functionality, to also (de)highlight lines in source window

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -88,6 +88,7 @@ Keys:
     F1/? - show this help screen
     q - quit
 
+    Ctrl-r - reload breakpoints from saved-breakpoints file
     Ctrl-c - when in continue mode, break back to PuDB
     Ctrl-l - redraw screen
 

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1955,26 +1955,12 @@ class DebuggerUI(FrameVarInfoKeeper):
             raw_input("Hit Enter to return:")
             self.screen.start()
 
-        def reload_breakpoints_and_redisplay(w, size, key):
-            bp_source_identifier = \
-                self.source_code_provider.get_source_identifier()
+        def reload_breakpoints_and_redisplay():
+            reload_breakpoints()
+            self.set_source_code_provider(self.source_code_provider,
+                                          force_update=True)
 
-            def set_of_line_nums_from_bp_list(bp_list):
-                result = set()
-                for bp in bp_list:
-                    if bp_source_identifier == bp.file and \
-                       bp.line-1 < len(self.source) and bp.enabled:
-                        result.add(bp.line)
-                return result
-            old_bps = set_of_line_nums_from_bp_list(self._get_bp_list())
-            reload_breakpoints(w, size, key)
-            new_bps = set_of_line_nums_from_bp_list(self._get_bp_list())
-            for bp_line in new_bps - old_bps:  # highlight newly added bps
-                self.source[bp_line-1].set_breakpoint(True)
-            for bp_line in old_bps - new_bps:  # de-highlight deleted bps
-                self.source[bp_line-1].set_breakpoint(False)
-
-        def reload_breakpoints(w, size, key):
+        def reload_breakpoints():
             self.debugger.clear_all_breaks()
             from pudb.settings import load_breakpoints
             for bpoint_descr in load_breakpoints():
@@ -2091,7 +2077,8 @@ class DebuggerUI(FrameVarInfoKeeper):
             open_file_editor(source_identifier, pos+1)
 
         self.top.listen("o", show_output)
-        self.top.listen("ctrl r", reload_breakpoints_and_redisplay)
+        self.top.listen("ctrl r",
+                        lambda a, b, c: reload_breakpoints_and_redisplay())
         self.top.listen("!", run_cmdline)
         self.top.listen("e", show_traceback)
 

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1954,6 +1954,25 @@ class DebuggerUI(FrameVarInfoKeeper):
             raw_input("Hit Enter to return:")
             self.screen.start()
 
+        def reload_breakpoints_and_redisplay(w, size, key):
+            bp_source_identifier = \
+                self.source_code_provider.get_source_identifier()
+
+            def set_of_line_nums_from_bp_list(bp_list):
+                result = set()
+                for bp in bp_list:
+                    if bp_source_identifier == bp.file and \
+                       bp.line-1 < len(self.source) and bp.enabled:
+                        result.add(bp.line)
+                return result
+            old_bps = set_of_line_nums_from_bp_list(self._get_bp_list())
+            reload_breakpoints(w, size, key)
+            new_bps = set_of_line_nums_from_bp_list(self._get_bp_list())
+            for bp_line in new_bps - old_bps:  # highlight newly added bps
+                self.source[bp_line-1].set_breakpoint(True)
+            for bp_line in old_bps - new_bps:  # de-highlight deleted bps
+                self.source[bp_line-1].set_breakpoint(False)
+            
         def reload_breakpoints(w, size, key):
             self.debugger.clear_all_breaks()
             from pudb.settings import load_breakpoints
@@ -2071,7 +2090,7 @@ class DebuggerUI(FrameVarInfoKeeper):
             open_file_editor(source_identifier, pos+1)
 
         self.top.listen("o", show_output)
-        self.top.listen("ctrl r", reload_breakpoints)
+        self.top.listen("ctrl r", reload_breakpoints_and_redisplay)
         self.top.listen("!", run_cmdline)
         self.top.listen("e", show_traceback)
 

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -2082,7 +2082,7 @@ class DebuggerUI(FrameVarInfoKeeper):
 
         self.top.listen("o", show_output)
         self.top.listen("ctrl r",
-                        lambda a, b, c: reload_breakpoints_and_redisplay())
+                        lambda w, size, key: reload_breakpoints_and_redisplay())
         self.top.listen("!", run_cmdline)
         self.top.listen("e", show_traceback)
 

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1957,8 +1957,12 @@ class DebuggerUI(FrameVarInfoKeeper):
 
         def reload_breakpoints_and_redisplay():
             reload_breakpoints()
+            curr_line = self.current_line
             self.set_source_code_provider(self.source_code_provider,
                                           force_update=True)
+            if curr_line is not None:
+                self.current_line = self.source[int(curr_line.line_nr)-1]
+                self.current_line.set_current(True)
 
         def reload_breakpoints():
             self.debugger.clear_all_breaks()

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1972,7 +1972,7 @@ class DebuggerUI(FrameVarInfoKeeper):
                 self.source[bp_line-1].set_breakpoint(True)
             for bp_line in old_bps - new_bps:  # de-highlight deleted bps
                 self.source[bp_line-1].set_breakpoint(False)
-            
+
         def reload_breakpoints(w, size, key):
             self.debugger.clear_all_breaks()
             from pudb.settings import load_breakpoints


### PR DESCRIPTION
Function `reload_breakpoints`, which is called with shortcut `ctrl+r`, re-reads breakpoints from `saved-breakpoints` file, which is very useful when that file is edited externally by other programs (such as [https://github.com/lieryan/vim-pudb](url)). However, this function does not update source code window to highlight newly added breakpoints, or de-highlight deleted breakpoints.

A wrapper, around that function is added : `reload_breakpoints_and_redisplay`. Besides calling the old function itself, it also sets proper highlighting in source code window : it highlights newly added breakpoints, and de-highlights deleted ones. Old function still remains to be used wherever it's needed as it was.

Also, `ctrl+r` now calls new function.