### PR TITLE
Make the type stringifier just call type(), convert old type stringifier to a "default" stringifier

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -108,7 +108,7 @@ Keys in variables list:
     \/enter/space - expand/collapse
     h - collapse
     l - expand
-    t/r/s/i/c - show type/repr/str/id/custom for this variable
+    d/t/r/s/i/c - show default/type/repr/str/id/custom for this variable
     H - toggle highlighting
     @ - toggle repetition at top
     * - cycle attribute visibility: public/_private/__dunder__
@@ -913,6 +913,8 @@ class DebuggerUI(FrameVarInfoKeeper):
                 focus_index = collapse_current(var, pos, iinfo)
             elif key == "l":
                 iinfo.show_detail = True
+            elif key == "d":
+                iinfo.display_type = "default"
             elif key == "t":
                 iinfo.display_type = "type"
             elif key == "r":
@@ -969,7 +971,9 @@ class DebuggerUI(FrameVarInfoKeeper):
                 title = "Variable Inspection Options"
 
             rb_grp_show = []
-            rb_show_type = urwid.RadioButton(rb_grp_show, "Show Type",
+            rb_show_default = urwid.RadioButton(rb_grp_show, "Default",
+                    iinfo.display_type == "default")
+            rb_show_type = urwid.RadioButton(rb_grp_show, "Show type()",
                     iinfo.display_type == "type")
             rb_show_repr = urwid.RadioButton(rb_grp_show, "Show repr()",
                     iinfo.display_type == "repr")
@@ -1020,7 +1024,9 @@ class DebuggerUI(FrameVarInfoKeeper):
                 iinfo.repeated_at_top = repeated_at_top_checkbox.get_state()
                 iinfo.show_methods = show_methods_checkbox.get_state()
 
-                if rb_show_type.get_state():
+                if rb_show_default.get_state():
+                    iinfo.display_type = "default"
+                elif rb_show_type.get_state():
                     iinfo.display_type = "type"
                 elif rb_show_repr.get_state():
                     iinfo.display_type = "repr"
@@ -1072,6 +1078,7 @@ class DebuggerUI(FrameVarInfoKeeper):
         self.var_list.listen(" ", change_var_state)
         self.var_list.listen("h", change_var_state)
         self.var_list.listen("l", change_var_state)
+        self.var_list.listen("d", change_var_state)
         self.var_list.listen("t", change_var_state)
         self.var_list.listen("r", change_var_state)
         self.var_list.listen("s", change_var_state)

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -343,14 +343,14 @@ def edit_config(ui, conf_dict):
 
     # {{{ stringifier
 
-    stringifier_opts = ["type", "str", "repr", "id"]
+    stringifier_opts = ["default", "type", "str", "repr", "id"]
     known_stringifier = conf_dict["stringifier"] in stringifier_opts
     stringifier_rb_group = []
     stringifier_edit = urwid.Edit(edit_text=conf_dict["custom_stringifier"])
     stringifier_info = urwid.Text("This is the default function that will be "
         "called on variables in the variables list.  Note that you can change "
         "this on a per-variable basis by selecting a variable and hitting Enter "
-        "or by typing t/s/r.  Note that str and repr will be slower than type "
+        "or by typing d/t/s/r/i.  Note that str and repr will be slower than type "
         "and have the potential to crash PuDB.\n")
     stringifier_edit_list_item = urwid.AttrMap(stringifier_edit, "value")
     stringifier_rbs = [

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -343,7 +343,7 @@ def edit_config(ui, conf_dict):
 
     # {{{ stringifier
 
-    stringifier_opts = ["default", "type", "str", "repr", "id"]
+    stringifier_opts = ["default", "type", "repr", "str", "id"]
     known_stringifier = conf_dict["stringifier"] in stringifier_opts
     stringifier_rb_group = []
     stringifier_edit = urwid.Edit(edit_text=conf_dict["custom_stringifier"])
@@ -351,7 +351,7 @@ def edit_config(ui, conf_dict):
         "This is the default function that will be called on variables in the "
         "variables list. You can also change this on a per-variable basis by "
         "selecting a variable and typing 'e' to edit the variable's display "
-        "settings, or by typing one of d/t/s/r/i/c. Note that str and repr will "
+        "settings, or by typing one of d/t/r/s/i/c. Note that str and repr will "
         "be slower than the default, type, or id stringifiers.\n")
     stringifier_edit_list_item = urwid.AttrMap(stringifier_edit, "value")
     stringifier_rbs = [

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -343,7 +343,8 @@ def edit_config(ui, conf_dict):
 
     # {{{ stringifier
 
-    stringifier_opts = ["default", "type", "repr", "str", "id"]
+    from pudb.var_view import STRINGIFIERS
+    stringifier_opts = list(STRINGIFIERS.keys())
     known_stringifier = conf_dict["stringifier"] in stringifier_opts
     stringifier_rb_group = []
     stringifier_edit = urwid.Edit(edit_text=conf_dict["custom_stringifier"])

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -347,11 +347,12 @@ def edit_config(ui, conf_dict):
     known_stringifier = conf_dict["stringifier"] in stringifier_opts
     stringifier_rb_group = []
     stringifier_edit = urwid.Edit(edit_text=conf_dict["custom_stringifier"])
-    stringifier_info = urwid.Text("This is the default function that will be "
-        "called on variables in the variables list.  Note that you can change "
-        "this on a per-variable basis by selecting a variable and hitting Enter "
-        "or by typing d/t/s/r/i.  Note that str and repr will be slower than type "
-        "and have the potential to crash PuDB.\n")
+    stringifier_info = urwid.Text(
+        "This is the default function that will be called on variables in the "
+        "variables list. You can also change this on a per-variable basis by "
+        "selecting a variable and typing 'e' to edit the variable's display "
+        "settings, or by typing one of d/t/s/r/i/c. Note that str and repr will "
+        "be slower than the default, type, or id stringifiers.\n")
     stringifier_edit_list_item = urwid.AttrMap(stringifier_edit, "value")
     stringifier_rbs = [
             urwid.RadioButton(stringifier_rb_group, name,

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -466,7 +466,6 @@ def get_stringifier(iinfo: InspectInfo) -> Callable:
             if "pudb_stringifier" not in custom_stringifier_dict:
                 ui_log.error(f"{iinfo.display_type} does not contain a function "
                              "named pudb_stringifier at the module level.")
-                input("Hit enter:")
                 return lambda value: str(
                         "ERROR: Invalid custom stringifier file: "
                         "pudb_stringifer not defined.")

--- a/test/test_var_view.py
+++ b/test/test_var_view.py
@@ -6,10 +6,13 @@ import unittest
 from pudb.var_view import (
     BasicValueWalker,
     FrameVarInfo,
+    InspectInfo,
     PudbCollection,
     PudbMapping,
     PudbSequence,
+    STRINGIFIERS,
     ValueWalker,
+    get_stringifier,
     ui_log,
 )
 
@@ -23,8 +26,6 @@ class A2:
 
 
 def test_get_stringifier():
-    from pudb.var_view import InspectInfo, get_stringifier
-
     try:
         import numpy as np
     except ImportError:
@@ -36,7 +37,7 @@ def test_get_stringifier():
             A, A2, A(), A2(), "lól".encode(), "lól",
             1233123, ["lól".encode(), "lól"],
             ] + numpy_values:
-        for display_type in ["type", "repr", "str", "id"]:
+        for display_type in STRINGIFIERS:
             iinfo = InspectInfo()
             iinfo.display_type = display_type
 


### PR DESCRIPTION
This should address #384 as the logic for handling the "basic" types is now wrapped up in the "default" stringifier, which means you can now use other stringifiers on things like strings, ints, and booleans.