### PR TITLE
Give the correct length of remaining mapping items to expand in the variable view

### DIFF
--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -107,7 +107,7 @@ def load_config():
 
     conf_dict.setdefault("current_stack_frame", "top")
 
-    conf_dict.setdefault("stringifier", "type")
+    conf_dict.setdefault("stringifier", "default")
 
     conf_dict.setdefault("custom_theme", "")
     conf_dict.setdefault("custom_stringifier", "")

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -84,6 +84,10 @@ class PudbCollection(ABC):
                          "not behave like one: {m}".format(
                              l=label, m=error))
 
+    @classmethod
+    def length(cls, collection):
+        return len(collection)
+
 
 class PudbSequence(ABC):
     @classmethod
@@ -112,6 +116,10 @@ class PudbSequence(ABC):
             ui_log.error("Object {l!r} appears to be a sequence, but does "
                          "not behave like one: {m}".format(
                              l=label, m=error))
+
+    @classmethod
+    def length(cls, sequence):
+        return len(sequence)
 
 
 class PudbMapping(ABC):
@@ -150,6 +158,10 @@ class PudbMapping(ABC):
             ui_log.error("Object {l!r} appears to be a mapping, but does "
                          "not behave like one: {m}".format(
                              l=label, m=error))
+
+    @classmethod
+    def length(cls, mapping):
+        return len(mapping.keys())
 
 
 # Order is important here- A mapping without keys could be viewed as a
@@ -527,7 +539,7 @@ class ValueWalker(ABC):
             is_empty = False
             if count > 0 and count % 10 == 0:
                 try:
-                    length = len(value)
+                    length = container_cls.length(value)
                 except Exception:
                     length = -1
                 if self.add_continuation_item(parent, id_path, count, length):


### PR DESCRIPTION
Bit of an oversight on my part, that comes into play with Pandas in particular but probably others as well. The "X items omitted" message was wrong for DataFrames: the length of a dataframe is the number of rows, but its keys are the columns. I changed it so that the length of the mapping's keys is checked instead of just the length of the mapping.

There's also a commit in here to make the "default" stringifier the actual default (d'oh).