### PR TITLE
[fix] find HOME value when abstent using os.path.expanduser

### DIFF
--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -32,6 +32,7 @@ from pudb.lowlevel import (lookup_module, get_breakpoint_invalid_reason,
 
 # minor LGPL violation: stolen from python-xdg
 
+# see https://github.com/inducer/pudb/pull/453 for context
 _home = os.environ.get("HOME", os.path.expanduser("~"))
 xdg_data_home = os.environ.get("XDG_DATA_HOME",
             os.path.join(_home, ".local", "share") if _home else None)

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -32,7 +32,7 @@ from pudb.lowlevel import (lookup_module, get_breakpoint_invalid_reason,
 
 # minor LGPL violation: stolen from python-xdg
 
-_home = os.environ.get("HOME", None)
+_home = os.environ.get("HOME", os.path.expanduser("~"))
 xdg_data_home = os.environ.get("XDG_DATA_HOME",
             os.path.join(_home, ".local", "share") if _home else None)
 


### PR DESCRIPTION
Hello,

This fix might appear in a weird context for you, the situation is:

- using pudb
- via [pytest-pudb](https://github.com/wronglink/pytest-pudb/)
- while calling pytest via tox
- the configuration will be ignored because: [pytest won't pass down the $HOME variable by default](https://tox.readthedocs.io/en/latest/example/basic.html#passing-down-environment-variables)
- thus you end up having to redo your configuration at every startup (which can be a dozen times per day)
- thus this is very annoying and and this is actually extremely not intuitive to debug (like I've spent a few hours in the source code)

So to handle this situation I'm using the `os.path.expanduser("~")` way to still get the user's home (maybe there's a better way?)

But to be honest I'm not sure where this need to be fixed?

You can do this in every tox file but it's a bit annoying to modify it only for debugging:

```ini
[testenv]
setenv =
  HOME={homedir}
```

Or maybe [it should be fixed in pytest-pudb?](https://github.com/wronglink/pytest-pudb/pull/23)

Or maybe directly in pudb because this will be a broader fix for more people?

I'm not sure

Nevertheless thanks a lot for this debugger, it really help me a lot!

Kind regards,