### PR TITLE
Use bpython.embed instead of deprecated bpython.cli.main

### DIFF
--- a/pudb/shell.py
+++ b/pudb/shell.py
@@ -110,8 +110,8 @@ def run_classic_shell(globals, locals):
 def run_bpython_shell(globals, locals):
     ns = SetPropagatingDict([locals, globals], locals)
 
-    import bpython.cli
-    bpython.cli.main(args=[], locals_=ns)
+    import bpython
+    bpython.embed(args=[], locals_=ns)
 
 
 # {{{ ipython


### PR DESCRIPTION
Thanks for pudb - it is great. I like to use bpython with it, and I have been getting deprecation notices (see [bpython.cli.main](https://github.com/bpython/bpython/blob/d07a405fe6b4ac8c51f7603db113dd88ed6713ae/bpython/cli.py#L1944)). In addition, the old interface had issues with ANSI color sequences, and the `bpython.embed` does not.

The current way of using this should be similar to ptpython, i,.e. using the `bpython.embed`.

Just a 2 line change - see below.