### PR TITLE
Source formatter refactor

### DIFF
--- a/pudb/source_view.py
+++ b/pudb/source_view.py
@@ -253,6 +253,7 @@ else:
         t.Literal: "literal",
         t.Name.Exception: "exception",
         t.Name.Function: "name",
+        t.Name.Function.Magic: "magic",
         t.Name.Class: "name",
         t.Name.Builtin: "builtin",
         t.Name.Builtin.Pseudo: "pseudo",
@@ -316,10 +317,10 @@ else:
                     ttype = ATTR_TRANSLATE[ttype][s]
 
             # Translate dunder method tokens
-            if ttype == (
-                    t.Name.Function
-                    and s.startswith("__") and s.endswith("__")
-                    ):
+            # NOTE: leaves "Magic" name tokens alone
+            if (ttype == t.Name.Function
+                    and s.startswith("__")
+                    and s.endswith("__")):
                 ttype = t.Token.Dunder
 
             while ttype not in ATTR_MAP:

--- a/pudb/source_view.py
+++ b/pudb/source_view.py
@@ -260,8 +260,6 @@ else:
         t.Punctuation: "punctuation",
         t.Operator: "operator",
         t.String: "string",
-        # XXX: Single and Double don't actually work yet.
-        # See https://bitbucket.org/birkenfeld/pygments-main/issue/685
         t.String.Double: "doublestring",
         t.String.Single: "singlestring",
         t.String.Backtick: "backtick",

--- a/pudb/source_view.py
+++ b/pudb/source_view.py
@@ -159,155 +159,6 @@ class SourceLine(urwid.FlowWidget):
         return key
 
 
-def format_source(debugger_ui, lines, breakpoints):
-    lineno_format = "%%%dd " % (len(str(len(lines))))
-    try:
-        import pygments  # noqa
-    except ImportError:
-        return [SourceLine(debugger_ui,
-            line.rstrip("\n\r").expandtabs(TABSTOP),
-            lineno_format % (i+1), None,
-            has_breakpoint=i+1 in breakpoints)
-            for i, line in enumerate(lines)]
-    else:
-        from pygments import highlight
-        from pygments.lexers import PythonLexer
-        from pygments.formatter import Formatter
-        import pygments.token as t
-
-        result = []
-        argument_parser = ArgumentParser(t)
-
-        # NOTE: Tokens of the form t.Token.<name> are not native
-        #       Pygments token types; they are user defined token
-        #       types.
-        #
-        #       t.Token is a Pygments token creator object
-        #       (see http://pygments.org/docs/tokens/)
-        #
-        #       The user defined token types get assigned by
-        #       one of several translation operations at the
-        #       beginning of add_snippet().
-        #
-        ATTR_MAP = {  # noqa: N806
-                t.Token: "source",
-                t.Keyword.Namespace: "namespace",
-                t.Token.Argument: "argument",
-                t.Token.Dunder: "dunder",
-                t.Token.Keyword2: "keyword2",
-                t.Keyword: "keyword",
-                t.Literal: "literal",
-                t.Name.Exception: "exception",
-                t.Name.Function: "name",
-                t.Name.Class: "name",
-                t.Name.Builtin: "builtin",
-                t.Name.Builtin.Pseudo: "pseudo",
-                t.Punctuation: "punctuation",
-                t.Operator: "operator",
-                t.String: "string",
-                # XXX: Single and Double don't actually work yet.
-                # See https://bitbucket.org/birkenfeld/pygments-main/issue/685
-                t.String.Double: "doublestring",
-                t.String.Single: "singlestring",
-                t.String.Backtick: "backtick",
-                t.String.Doc: "docstring",
-                t.Comment: "comment",
-                }
-
-        # Token translation table. Maps token types and their
-        # associated strings to new token types.
-        ATTR_TRANSLATE = {  # noqa: N806
-                t.Keyword: {
-                    "class": t.Token.Keyword2,
-                    "def": t.Token.Keyword2,
-                    "exec": t.Token.Keyword2,
-                    "lambda": t.Token.Keyword2,
-                    "print": t.Token.Keyword2,
-                    },
-                t.Operator: {
-                    ".": t.Token,
-                    },
-                t.Name.Builtin.Pseudo: {
-                    "self": t.Token,
-                    },
-                t.Name.Builtin: {
-                    "object": t.Name.Class,
-                    },
-                }
-
-        class UrwidFormatter(Formatter):
-            def __init__(subself, **options):  # noqa: N805, E501 # pylint: disable=no-self-argument
-                Formatter.__init__(subself, **options)
-                subself.current_line = ""
-                subself.current_attr = []
-                subself.lineno = 1
-
-            def format(subself, tokensource, outfile):  # noqa: N805, E501 # pylint: disable=no-self-argument
-                def add_snippet(ttype, s):
-                    if not s:
-                        return
-
-                    # Find function arguments. When found, change their
-                    # ttype to t.Token.Argument
-                    new_ttype = argument_parser.parse_token(ttype, s)
-                    if new_ttype:
-                        ttype = new_ttype
-
-                    # Translate tokens
-                    if ttype in ATTR_TRANSLATE:
-                        if s in ATTR_TRANSLATE[ttype]:
-                            ttype = ATTR_TRANSLATE[ttype][s]
-
-                    # Translate dunder method tokens
-                    if ttype == (
-                            t.Name.Function
-                            and s.startswith("__") and s.endswith("__")
-                            ):
-                        ttype = t.Token.Dunder
-
-                    while ttype not in ATTR_MAP:
-                        if ttype.parent is not None:
-                            ttype = ttype.parent
-                        else:
-                            raise RuntimeError(
-                                    "untreated token type: %s" % str(ttype))
-
-                    attr = ATTR_MAP[ttype]
-
-                    subself.current_line += s
-                    subself.current_attr.append((attr, len(s)))
-
-                def shipout_line():
-                    result.append(
-                            SourceLine(debugger_ui,
-                                subself.current_line,
-                                lineno_format % subself.lineno,
-                                subself.current_attr,
-                                has_breakpoint=subself.lineno in breakpoints))
-                    subself.current_line = ""
-                    subself.current_attr = []
-                    subself.lineno += 1
-
-                for ttype, value in tokensource:
-                    while True:
-                        newline_pos = value.find("\n")
-                        if newline_pos == -1:
-                            add_snippet(ttype, value)
-                            break
-                        else:
-                            add_snippet(ttype, value[:newline_pos])
-                            shipout_line()
-                            value = value[newline_pos+1:]
-
-                if subself.current_line:
-                    shipout_line()
-
-        highlight("".join(line.expandtabs(TABSTOP) for line in lines),
-                PythonLexer(stripnl=False), UrwidFormatter())
-
-        return result
-
-
 class ParseState:
     """States for the ArgumentParser class"""
     idle = 1
@@ -356,3 +207,167 @@ class ArgumentParser:
             if self.paren_level == 0:
                 self.state = ParseState.idle
         return None
+
+
+try:
+    import pygments  # noqa
+except ImportError:
+    def format_source(debugger_ui, lines, breakpoints):
+        lineno_format = "%%%dd " % (len(str(len(lines))))
+        return [
+            SourceLine(
+                debugger_ui,
+                line.rstrip("\n\r").expandtabs(TABSTOP),
+                lineno_format % (i+1),
+                None,
+                has_breakpoint=i+1 in breakpoints,
+            )
+            for i, line in enumerate(lines)
+        ]
+else:
+    from pygments import highlight
+    from pygments.lexers import PythonLexer
+    from pygments.formatter import Formatter
+    import pygments.token as t
+
+    argument_parser = ArgumentParser(t)
+
+    # NOTE: Tokens of the form t.Token.<name> are not native
+    #       Pygments token types; they are user defined token
+    #       types.
+    #
+    #       t.Token is a Pygments token creator object
+    #       (see http://pygments.org/docs/tokens/)
+    #
+    #       The user defined token types get assigned by
+    #       one of several translation operations at the
+    #       beginning of add_snippet().
+    #
+    ATTR_MAP = {  # noqa: N806
+            t.Token: "source",
+            t.Keyword.Namespace: "namespace",
+            t.Token.Argument: "argument",
+            t.Token.Dunder: "dunder",
+            t.Token.Keyword2: "keyword2",
+            t.Keyword: "keyword",
+            t.Literal: "literal",
+            t.Name.Exception: "exception",
+            t.Name.Function: "name",
+            t.Name.Class: "name",
+            t.Name.Builtin: "builtin",
+            t.Name.Builtin.Pseudo: "pseudo",
+            t.Punctuation: "punctuation",
+            t.Operator: "operator",
+            t.String: "string",
+            # XXX: Single and Double don't actually work yet.
+            # See https://bitbucket.org/birkenfeld/pygments-main/issue/685
+            t.String.Double: "doublestring",
+            t.String.Single: "singlestring",
+            t.String.Backtick: "backtick",
+            t.String.Doc: "docstring",
+            t.Comment: "comment",
+            }
+
+    # Token translation table. Maps token types and their
+    # associated strings to new token types.
+    ATTR_TRANSLATE = {  # noqa: N806
+            t.Keyword: {
+                "class": t.Token.Keyword2,
+                "def": t.Token.Keyword2,
+                "exec": t.Token.Keyword2,
+                "lambda": t.Token.Keyword2,
+                "print": t.Token.Keyword2,
+                },
+            t.Operator: {
+                ".": t.Token,
+                },
+            t.Name.Builtin.Pseudo: {
+                "self": t.Token,
+                },
+            t.Name.Builtin: {
+                "object": t.Name.Class,
+                },
+            }
+
+    class UrwidFormatter(Formatter):
+        def __init__(self, debugger_ui, lineno_format, breakpoints, **options):
+            Formatter.__init__(self, **options)
+            self.current_line = ""
+            self.current_attr = []
+            self.lineno = 1
+            self.result = []
+            self.debugger_ui = debugger_ui
+            self.lineno_format = lineno_format
+            self.breakpoints = breakpoints
+
+        def format(self, tokensource, outfile):
+            def add_snippet(ttype, s):
+                if not s:
+                    return
+
+                # Find function arguments. When found, change their
+                # ttype to t.Token.Argument
+                new_ttype = argument_parser.parse_token(ttype, s)
+                if new_ttype:
+                    ttype = new_ttype
+
+                # Translate tokens
+                if ttype in ATTR_TRANSLATE:
+                    if s in ATTR_TRANSLATE[ttype]:
+                        ttype = ATTR_TRANSLATE[ttype][s]
+
+                # Translate dunder method tokens
+                if ttype == (
+                        t.Name.Function
+                        and s.startswith("__") and s.endswith("__")
+                        ):
+                    ttype = t.Token.Dunder
+
+                while ttype not in ATTR_MAP:
+                    if ttype.parent is not None:
+                        ttype = ttype.parent
+                    else:
+                        raise RuntimeError(
+                                "untreated token type: %s" % str(ttype))
+
+                attr = ATTR_MAP[ttype]
+
+                self.current_line += s
+                self.current_attr.append((attr, len(s)))
+
+            def shipout_line():
+                self.result.append(
+                    SourceLine(
+                        self.debugger_ui,
+                        self.current_line,
+                        self.lineno_format % self.lineno,
+                        self.current_attr,
+                        has_breakpoint=self.lineno in self.breakpoints,
+                    ))
+                self.current_line = ""
+                self.current_attr = []
+                self.lineno += 1
+
+            for ttype, value in tokensource:
+                while True:
+                    newline_pos = value.find("\n")
+                    if newline_pos == -1:
+                        add_snippet(ttype, value)
+                        break
+                    else:
+                        add_snippet(ttype, value[:newline_pos])
+                        shipout_line()
+                        value = value[newline_pos+1:]
+
+            if self.current_line:
+                shipout_line()
+
+    def format_source(debugger_ui, lines, breakpoints):
+        lineno_format = "%%%dd " % (len(str(len(lines))))
+        formatter = UrwidFormatter(debugger_ui, lineno_format, breakpoints)
+        highlight(
+            "".join(line.expandtabs(TABSTOP) for line in lines),
+            PythonLexer(stripnl=False),
+            formatter,
+        )
+        return formatter.result

--- a/pudb/source_view.py
+++ b/pudb/source_view.py
@@ -244,29 +244,29 @@ else:
     #       beginning of add_snippet().
     #
     ATTR_MAP = {  # noqa: N806
-            t.Token: "source",
-            t.Keyword.Namespace: "namespace",
-            t.Token.Argument: "argument",
-            t.Token.Dunder: "dunder",
-            t.Token.Keyword2: "keyword2",
-            t.Keyword: "keyword",
-            t.Literal: "literal",
-            t.Name.Exception: "exception",
-            t.Name.Function: "name",
-            t.Name.Class: "name",
-            t.Name.Builtin: "builtin",
-            t.Name.Builtin.Pseudo: "pseudo",
-            t.Punctuation: "punctuation",
-            t.Operator: "operator",
-            t.String: "string",
-            # XXX: Single and Double don't actually work yet.
-            # See https://bitbucket.org/birkenfeld/pygments-main/issue/685
-            t.String.Double: "doublestring",
-            t.String.Single: "singlestring",
-            t.String.Backtick: "backtick",
-            t.String.Doc: "docstring",
-            t.Comment: "comment",
-            }
+        t.Token: "source",
+        t.Keyword.Namespace: "namespace",
+        t.Token.Argument: "argument",
+        t.Token.Dunder: "dunder",
+        t.Token.Keyword2: "keyword2",
+        t.Keyword: "keyword",
+        t.Literal: "literal",
+        t.Name.Exception: "exception",
+        t.Name.Function: "name",
+        t.Name.Class: "name",
+        t.Name.Builtin: "builtin",
+        t.Name.Builtin.Pseudo: "pseudo",
+        t.Punctuation: "punctuation",
+        t.Operator: "operator",
+        t.String: "string",
+        # XXX: Single and Double don't actually work yet.
+        # See https://bitbucket.org/birkenfeld/pygments-main/issue/685
+        t.String.Double: "doublestring",
+        t.String.Single: "singlestring",
+        t.String.Backtick: "backtick",
+        t.String.Doc: "docstring",
+        t.Comment: "comment",
+    }
 
     # Token translation table. Maps token types and their
     # associated strings to new token types.
@@ -300,67 +300,67 @@ else:
             self.lineno_format = lineno_format
             self.breakpoints = breakpoints
 
+        def add_snippet(self, ttype, s):
+            if not s:
+                return
+
+            # Find function arguments. When found, change their
+            # ttype to t.Token.Argument
+            new_ttype = argument_parser.parse_token(ttype, s)
+            if new_ttype:
+                ttype = new_ttype
+
+            # Translate tokens
+            if ttype in ATTR_TRANSLATE:
+                if s in ATTR_TRANSLATE[ttype]:
+                    ttype = ATTR_TRANSLATE[ttype][s]
+
+            # Translate dunder method tokens
+            if ttype == (
+                    t.Name.Function
+                    and s.startswith("__") and s.endswith("__")
+                    ):
+                ttype = t.Token.Dunder
+
+            while ttype not in ATTR_MAP:
+                if ttype.parent is not None:
+                    ttype = ttype.parent
+                else:
+                    raise RuntimeError(
+                            "untreated token type: %s" % str(ttype))
+
+            attr = ATTR_MAP[ttype]
+
+            self.current_line += s
+            self.current_attr.append((attr, len(s)))
+
+        def shipout_line(self):
+            self.result.append(
+                SourceLine(
+                    self.debugger_ui,
+                    self.current_line,
+                    self.lineno_format % self.lineno,
+                    self.current_attr,
+                    has_breakpoint=self.lineno in self.breakpoints,
+                ))
+            self.current_line = ""
+            self.current_attr = []
+            self.lineno += 1
+
         def format(self, tokensource, outfile):
-            def add_snippet(ttype, s):
-                if not s:
-                    return
-
-                # Find function arguments. When found, change their
-                # ttype to t.Token.Argument
-                new_ttype = argument_parser.parse_token(ttype, s)
-                if new_ttype:
-                    ttype = new_ttype
-
-                # Translate tokens
-                if ttype in ATTR_TRANSLATE:
-                    if s in ATTR_TRANSLATE[ttype]:
-                        ttype = ATTR_TRANSLATE[ttype][s]
-
-                # Translate dunder method tokens
-                if ttype == (
-                        t.Name.Function
-                        and s.startswith("__") and s.endswith("__")
-                        ):
-                    ttype = t.Token.Dunder
-
-                while ttype not in ATTR_MAP:
-                    if ttype.parent is not None:
-                        ttype = ttype.parent
-                    else:
-                        raise RuntimeError(
-                                "untreated token type: %s" % str(ttype))
-
-                attr = ATTR_MAP[ttype]
-
-                self.current_line += s
-                self.current_attr.append((attr, len(s)))
-
-            def shipout_line():
-                self.result.append(
-                    SourceLine(
-                        self.debugger_ui,
-                        self.current_line,
-                        self.lineno_format % self.lineno,
-                        self.current_attr,
-                        has_breakpoint=self.lineno in self.breakpoints,
-                    ))
-                self.current_line = ""
-                self.current_attr = []
-                self.lineno += 1
-
             for ttype, value in tokensource:
                 while True:
                     newline_pos = value.find("\n")
                     if newline_pos == -1:
-                        add_snippet(ttype, value)
+                        self.add_snippet(ttype, value)
                         break
                     else:
-                        add_snippet(ttype, value[:newline_pos])
-                        shipout_line()
+                        self.add_snippet(ttype, value[:newline_pos])
+                        self.shipout_line()
                         value = value[newline_pos+1:]
 
             if self.current_line:
-                shipout_line()
+                self.shipout_line()
 
     def format_source(debugger_ui, lines, breakpoints):
         lineno_format = "%%%dd " % (len(str(len(lines))))

--- a/pudb/theme.py
+++ b/pudb/theme.py
@@ -74,6 +74,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
         ("builtin",             "source"),
         ("pseudo",              "source"),
         ("dunder",              "name"),
+        ("magic",               "dunder"),
         ("exception",           "source"),
         ("keyword2",            "keyword"),
         ("current line marker", "source"),
@@ -91,6 +92,7 @@ def get_palette(may_use_fancy_formats, theme="classic"):
         "builtin":   None,
         "pseudo":    None,
         "dunder":    None,
+        "magic":     None,
         "exception": None,
         "keyword2":  None,
 


### PR DESCRIPTION
It bugged me that `UrwidFormatter` was being redefined on every call to `format_source`, so I've refactored it out of the function. Does this seem sensible? Also included is a fix to "dunder" method detection logic and the addition of highlighting support for "magic" methods.

By the way, I've been thinking about making it easier to create custom themes by not really having any default highlighting- build out the inheritance map to cover all tokens, and in the default pallette just define all tokens as `None`.