### PR TITLE
Display path of current source file in header bar

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -2642,10 +2642,8 @@ class DebuggerUI(FrameVarInfoKeeper):
         self.current_exc_tuple = exc_tuple
 
         from pudb import VERSION
-        caption = [(None,
-            "PuDB %s - ?:help  n:next  s:step into  b:breakpoint  "
-            "!:python command line"
-            % VERSION)]
+        caption = [(None, "PuDB %s - ?:help - %s" %
+                    (VERSION, self.source_code_provider.get_source_identifier()))]
 
         if self.debugger.post_mortem:
             if show_exc_dialog and exc_tuple is not None:


### PR DESCRIPTION
Currently, the full path of the current source file will be displayed.
This usually results in long path. When the path can't be displayed fully in 1 row for whatever reason (the window is resized, not enough space from the beginning,...), after a Ctrl-L (hotkey for redraw screen), it will be wrapped automatically, creating more rows as needed.

We have multiple options to resolve this:
- Leave as is
- Only display the filename
- Calculate the length of the string somehow (from $COLUMNS, for example)
- Let user decide in config file
- Other....

Let's discuss this