### PR TITLE
Fix crash when expanding variables in post-mortem

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -403,6 +403,7 @@ class Debugger(bdb.Bdb):
         self.stack, index = self.get_shortened_stack(frame, tb)
 
         if self.post_mortem:
+            self.stack.append((self.bottom_frame, self.bottom_frame.f_lineno))
             index = len(self.stack)-1
 
         self.set_frame_index(index)


### PR DESCRIPTION
Currently, `Debugger.stack` will be empty when entering post-mortem, leading to `IndexError` when user tries to expand variables in the Variables window.
This commit fixes that by restoring `Debugger.bottom_frame` to `Debugger.stack`.

fixes #233 