### PR TITLE
Fix function argument and "self" highlighting

### DIFF
--- a/pudb/source_view.py
+++ b/pudb/source_view.py
@@ -189,7 +189,7 @@ class ArgumentParser:
     def parse_token(self, token, s):
         """Parse token. Return None or replacement token type"""
         if self.state == ParseState.idle:
-            if token is self.t.Name.Function:
+            if token in (self.t.Name.Function, self.t.Name.Function.Magic):
                 self.state = ParseState.found_function
                 self.paren_level = 0
         elif self.state == ParseState.found_function:
@@ -197,8 +197,7 @@ class ArgumentParser:
                 self.state = ParseState.found_open_paren
                 self.paren_level = 1
         else:
-            if ((token is self.t.Name)
-                    or (token is self.t.Name.Builtin.Pseudo and s == "self")):
+            if (token is self.t.Name):
                 return self.t.Token.Argument
             elif token is self.t.Punctuation and s == ")":
                 self.paren_level -= 1
@@ -279,9 +278,6 @@ else:
                 },
             t.Operator: {
                 ".": t.Token,
-                },
-            t.Name.Builtin.Pseudo: {
-                "self": t.Token,
                 },
             t.Name.Builtin: {
                 "object": t.Name.Class,


### PR DESCRIPTION
There was a bug in the argument parser that prevented it from working on magic methods.

I've also re-enabled highlighting `self` under the "pseudo" style. It's not clear to me why this was disabled to begin with, though my best guess is that it had something to do with the argument parser bug producing apparently wonky results.