### PR TITLE
Breakpoint view fixes

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1172,25 +1172,24 @@ class DebuggerUI(FrameVarInfoKeeper):
 
         # {{{ breakpoint listeners
 
+        def set_breakpoint_source(bp):
+            bp_source_identifier = \
+                    self.source_code_provider.get_source_identifier()
+            if (bp.file
+                    and bp_source_identifier == bp.file
+                    and bp.line-1 < len(self.source)):
+                self.source[bp.line-1].set_breakpoint(bp.enabled)
+
         def save_breakpoints(w, size, key):
             self.debugger.save_breakpoints()
 
         def delete_breakpoint(w, size, key):
-            bp_source_identifier = \
-                    self.source_code_provider.get_source_identifier()
-
-            if bp_source_identifier is None:
-                self.message(
-                    "Cannot currently delete a breakpoint here--"
-                    "source code does not correspond to a file location. "
-                    "(perhaps this is generated code)")
-
             bp_list = self._get_bp_list()
             if bp_list:
                 _, pos = self.bp_list._w.get_focus()
                 bp = bp_list[pos]
-                if bp_source_identifier == bp.file and bp.line-1 < len(self.source):
-                    self.source[bp.line-1].set_breakpoint(False)
+                bp.enabled = False
+                set_breakpoint_source(bp)
 
                 err = self.debugger.clear_break(bp.file, bp.line)
                 if err:
@@ -1200,17 +1199,12 @@ class DebuggerUI(FrameVarInfoKeeper):
 
         def enable_disable_breakpoint(w, size, key):
             bp_entry, pos = self.bp_list._w.get_focus()
-
             if bp_entry is None:
                 return
-
             bp = self._get_bp_list()[pos]
             bp.enabled = not bp.enabled
-
-            sline = self.source[bp.line-1]
-            sline.set_breakpoint(bp.enabled)
-
             self.update_breakpoints()
+            set_breakpoint_source(bp)
 
         def examine_breakpoint(w, size, key):
             bp_entry, pos = self.bp_list._w.get_focus()

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1183,19 +1183,21 @@ class DebuggerUI(FrameVarInfoKeeper):
         def save_breakpoints(w, size, key):
             self.debugger.save_breakpoints()
 
-        def delete_breakpoint(w, size, key):
+        def handle_delete_breakpoint(w, size, key):
             bp_list = self._get_bp_list()
             if bp_list:
                 _, pos = self.bp_list._w.get_focus()
                 bp = bp_list[pos]
-                bp.enabled = False
-                set_breakpoint_source(bp)
+                delete_breakpoint(bp)
 
-                err = self.debugger.clear_break(bp.file, bp.line)
-                if err:
-                    self.message("Error clearing breakpoint:\n" + err)
-                else:
-                    self.update_breakpoints()
+        def delete_breakpoint(bp):
+            bp.enabled = False
+            set_breakpoint_source(bp)
+            err = self.debugger.clear_break(bp.file, bp.line)
+            if err:
+                self.message("Error clearing breakpoint:\n" + err)
+            else:
+                self.update_breakpoints()
 
         def enable_disable_breakpoint(w, size, key):
             bp_entry, pos = self.bp_list._w.get_focus()
@@ -1259,23 +1261,7 @@ class DebuggerUI(FrameVarInfoKeeper):
                         FileSourceCodeProvider(self.debugger, bp.file))
                 self.columns.set_focus(0)
             elif result == "del":
-                bp_source_identifier = \
-                        self.source_code_provider.get_source_identifier()
-
-                if bp_source_identifier is None:
-                    self.message(
-                        "Cannot currently delete a breakpoint here--"
-                        "source code does not correspond to a file location. "
-                        "(perhaps this is generated code)")
-
-                if bp_source_identifier == bp.file:
-                    self.source[bp.line-1].set_breakpoint(False)
-
-                err = self.debugger.clear_break(bp.file, bp.line)
-                if err:
-                    self.message("Error clearing breakpoint:\n" + err)
-                else:
-                    self.update_breakpoints()
+                delete_breakpoint(bp)
 
         def show_breakpoint(w, size, key):
             bp_entry, pos = self.bp_list._w.get_focus()
@@ -1286,7 +1272,7 @@ class DebuggerUI(FrameVarInfoKeeper):
                         FileSourceCodeProvider(self.debugger, bp.file))
 
         self.bp_list.listen("enter", show_breakpoint)
-        self.bp_list.listen("d", delete_breakpoint)
+        self.bp_list.listen("d", handle_delete_breakpoint)
         self.bp_list.listen("s", save_breakpoints)
         self.bp_list.listen("e", examine_breakpoint)
         self.bp_list.listen("b", enable_disable_breakpoint)

--- a/pudb/ui_tools.py
+++ b/pudb/ui_tools.py
@@ -204,9 +204,9 @@ class BreakpointFrame(urwid.FlowWidget):
         bp_pfx = bp_pfx.ljust(3)
 
         hits_label = "hits" if self.hits != 1 else "hit"
-        loc = " %s:%d (%s %s)" % (self.filename, self.line, self.hits, hits_label)
+        loc = f" {self.filename}:{self.line} ({self.hits} {hits_label})"
         text = bp_pfx+loc
-        attr = [(apfx+"breakpoint", len(loc))]
+        attr = [(apfx+"breakpoint", len(text))]
 
         return make_canvas([text], [attr], maxcol, apfx+"breakpoint")
 


### PR DESCRIPTION
I noticed that toggling a breakpoint from a different file caused the source in the current file to be highlighted as though the breakpoint was actually there instead. Also, sometimes we would just hit traceback in this scenario. I cleaned up the relevant logic so that shouldn't be a problem anymore.

To test:
* Run the `try_the_debugger.sh` script, open some other module with 'm', and set a breakpoint on a line in the first 60 lines of the file, and another on a line somewhere after line 60 (so there's no corresponding line in `debug_me`).
* Go back to the `debug_me` module and, using 'b' from the breakpoint view, try toggling those breakpoints in the other module.

I also added in the highlighting fix for the breakpoint view,  since I think my theme work is going to take a little while yet.