### PR TITLE
Add a "header warning" style for warnings in the header

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -2620,12 +2620,12 @@ class DebuggerUI(FrameVarInfoKeeper):
 
             caption.extend([
                 (None, " "),
-                ("warning", "[POST-MORTEM MODE]")
+                ("header warning", "[POST-MORTEM MODE]")
                 ])
         elif exc_tuple is not None:
             caption.extend([
                 (None, " "),
-                ("warning", "[PROCESSING EXCEPTION - hit 'e' to examine]")
+                ("header warning", "[PROCESSING EXCEPTION - hit 'e' to examine]")
                 ])
 
         self.caption.set_text(caption)

--- a/pudb/theme.py
+++ b/pudb/theme.py
@@ -425,7 +425,7 @@ def get_palette(may_use_fancy_formats: bool, theme: str = "classic") -> list:
             "header": ("dark blue", "light gray"),
             "dialog title": (add_setting("white", "bold"), "black"),
             "warning": (add_setting("light red", "bold"), "black"),
-            "warning": (add_setting("light red", "bold"), "light gray"),
+            "header warning": (add_setting("light red", "bold"), "light gray"),
             # }}}
             # {{{ source view
             "source": ("white", "black"),

--- a/pudb/theme.py
+++ b/pudb/theme.py
@@ -107,6 +107,7 @@ INHERITANCE_MAP = {
     "fixed value": "label",
 
     "warning": "highlighted",
+    "header warning": "warning",
     "search box": "focused input",
     "search not found": "warning",
     # }}}
@@ -362,6 +363,7 @@ def get_palette(may_use_fancy_formats: bool, theme: str = "classic") -> list:
             "input": ("black", "dark cyan"),
             "focused input": ("black", "light cyan"),
             "warning": (add_setting("dark red", "bold"), "white"),
+            "header warning": (add_setting("dark red", "bold"), "light gray"),
             # }}}
             # {{{ source view
             "source": ("black", "white"),
@@ -423,6 +425,7 @@ def get_palette(may_use_fancy_formats: bool, theme: str = "classic") -> list:
             "header": ("dark blue", "light gray"),
             "dialog title": (add_setting("white", "bold"), "black"),
             "warning": (add_setting("light red", "bold"), "black"),
+            "warning": (add_setting("light red", "bold"), "light gray"),
             # }}}
             # {{{ source view
             "source": ("white", "black"),
@@ -475,6 +478,7 @@ def get_palette(may_use_fancy_formats: bool, theme: str = "classic") -> list:
             "focused sidebar": (add_setting("black", "bold"), "light gray"),
             "group head": (add_setting("black", "bold"), "light gray"),
             "warning": (add_setting("light red", "bold"), "black"),
+            "header warning": (add_setting("light red", "bold"), "light gray"),
             "dialog title": ("black", "dark green"),
             "fixed value": ("white", "dark gray"),
             # }}}
@@ -533,6 +537,7 @@ def get_palette(may_use_fancy_formats: bool, theme: str = "classic") -> list:
             # {{{ general ui
             "dialog title": (add_setting("white", "bold"), "dark cyan"),
             "warning": (add_setting("light red", "bold"), "white"),
+            "header warning": (add_setting("light red", "bold"), "light gray"),
             "focused sidebar": ("dark red", "light gray"),
             "group head": (add_setting("yellow", "bold"), "light gray"),
             # }}}


### PR DESCRIPTION
This allows defining a general "warning" style that can be specialized for any of the specific uses. The others already have specific style (search not found, command line error).