### PR TITLE
Include contrib folder and pytorch stringifier

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,3 +84,11 @@ version control tool.::
     git clone https://github.com/inducer/pudb.git
 
 You may also `browse the code <https://github.com/inducer/pudb>`_ online.
+
+
+Customize and Extend PuDB
+-------------------------
+
+You can contribute your custom stringifiers, themes and shells under
+`pudb/contrib` folder. Currently the process is streamlined for stringifiers,
+while shells and themes will require some refactoring of the core PuDB code.

--- a/pudb/contrib/README.md
+++ b/pudb/contrib/README.md
@@ -1,0 +1,13 @@
+# Community contributed extensions for pudb
+
+Here the community can extend pudb with custom stringifiers, themes and shells.
+
+
+## How to contribute your stringifiers
+
+Simply add a new python module inside `contrib/stringifiers` that contains your custom stringifier.
+
+Then add your stringifier to the `CONTRIB_STRINGIFIERS` dict inside
+`contrib/stringifiers/__init__.py`.
+
+The new options should appear in the pudb settings pane after setting the `Enable community contributed content` option.

--- a/pudb/contrib/__init__.py
+++ b/pudb/contrib/__init__.py
@@ -1,0 +1,1 @@
+from pudb.contrib.stringifiers import CONTRIB_STRINGIFIERS

--- a/pudb/contrib/stringifiers/__init__.py
+++ b/pudb/contrib/stringifiers/__init__.py
@@ -1,0 +1,8 @@
+from pudb.contrib.stringifiers.torch_stringifier import torch_stringifier_fn
+
+CONTRIB_STRINGIFIERS = {
+    # User contributed stringifiers
+    # Use the contrib prefix for all keys to avoid clashes with the core stringifiers
+    # and make known to the user that this is community contributed code
+    "contrib.pytorch": torch_stringifier_fn,
+}

--- a/pudb/contrib/stringifiers/torch_stringifier.py
+++ b/pudb/contrib/stringifiers/torch_stringifier.py
@@ -1,0 +1,37 @@
+from typing import Any
+
+try:
+    import torch
+
+    HAVE_TORCH = 1
+except:
+    HAVE_TORCH = 0
+
+import pudb.var_view as vv
+
+
+def torch_stringifier_fn(value: Any) -> str:
+    if not HAVE_TORCH:
+        # Fall back to default stringifier
+
+        return vv.default_stringifier(value)
+
+    if isinstance(value, torch.nn.Module):
+        device: str = str(next(value.parameters()).device)
+        params: int = sum([p.numel() for p in value.parameters() if p.requires_grad])
+        rep: str = value.__repr__() if len(value.__repr__()) < 55 else type(
+            value
+        ).__name__
+
+        return "{}[{}] Params: {}".format(rep, device, params)
+    elif isinstance(value, torch.Tensor):
+        return "{}[{}][{}] {}".format(
+            type(value).__name__,
+            str(value.dtype).replace("torch.", ""),
+            str(value.device),
+            str(list(value.shape)),
+        )
+    else:
+        # Fall back to default stringifier
+
+        return vv.default_stringifier(value)

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -203,7 +203,8 @@ class InspectInfo:
         self.access_level = CONFIG["default_variables_access_level"]
         self.show_methods = False
         self.wrap = CONFIG["wrap_variables"]
-
+        self.enable_contrib_stringifiers = \
+                CONFIG["enable_community_contributed_content"]
 
 class WatchExpression:
     def __init__(self, expression):
@@ -456,11 +457,19 @@ STRINGIFIERS = {
 }
 
 
+import pudb.contrib.stringifiers as contrib
+
+
 def get_stringifier(iinfo: InspectInfo) -> Callable:
     """
     :return: a function that turns an object into a Unicode text object.
     """
     try:
+        if iinfo.display_type in contrib.CONTRIB_STRINGIFIERS:
+            if iinfo.enable_contrib_stringifiers:
+                return contrib.CONTRIB_STRINGIFIERS[iinfo.display_type]
+            else:
+                return STRINGIFIERS["default"]
         return STRINGIFIERS[iinfo.display_type]
     except KeyError:
         try:

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "Topic :: Terminals",
         "Topic :: Utilities",
     ],
-    packages=["pudb"],
+    packages=["pudb", "pudb.contrib", "pudb.contrib.stringifiers"],
     entry_points={
         "console_scripts": [
             # Deprecated. Should really use python -m pudb.

--- a/test/test_contrib_torch_stringifier.py
+++ b/test/test_contrib_torch_stringifier.py
@@ -1,0 +1,46 @@
+try:
+    import torch
+    HAVE_TORCH = True
+except ImportError:
+    HAVE_TORCH = False
+
+from pudb.var_view import default_stringifier
+from pudb.contrib.stringifiers.torch_stringifier import torch_stringifier_fn
+
+def test_tensor():
+    if HAVE_TORCH:
+        x = torch.randn(10, 5, 4)
+        assert torch_stringifier_fn(x) == "Tensor[float32][cpu] [10, 5, 4]"
+
+
+def test_conv_module():
+    if HAVE_TORCH:
+        x = torch.nn.Conv2d(20, 10, 3)
+        assert torch_stringifier_fn(x) == "Conv2d(20, 10, kernel_size=(3, 3), stride=(1, 1))[cpu] Params: 1810"
+
+
+def test_linear_module():
+    if HAVE_TORCH:
+        x = torch.nn.Linear(5, 2, bias=False)
+        assert torch_stringifier_fn(x) == "Linear(in_features=5, out_features=2, bias=False)[cpu] Params: 10"
+
+
+def test_long_module_repr_should_revert_to_type():
+    if HAVE_TORCH:
+        x = torch.nn.Transformer()
+        assert torch_stringifier_fn(x) == "Transformer[cpu] Params: 44140544"
+
+
+def test_reverts_to_default_for_str():
+    x = "Everyone has his day, and some days last longer than others."
+    assert torch_stringifier_fn(x) == default_stringifier(x)
+
+
+def test_reverts_to_default_for_dict():
+    x = {"a": 1, "b": 2, "c": 3}
+    assert torch_stringifier_fn(x) == default_stringifier(x)
+
+
+def test_reverts_to_default_for_list():
+    x = list(range(1000))
+    assert torch_stringifier_fn(x) == default_stringifier(x)


### PR DESCRIPTION
This PR introduces a new contrib folder under pudb for community
customization. A stringifier for pytorch is included.
Related issue: #475 

Detailed changelog:

* A module was added under pudb/contrib/stringifiers as place to store
  custom stringifiers.
* A stringifier for pytorch tensors and modules is included.
* An option was added in the settings menu for the user to enable or
  disable the cotrib content for users that want to stick to the core
  pudb installation.
* Changes were made in var_view.py and settings.py to allow for
  inclusion of the contrib/stringifiers in the configuration menu.

Signed-off-by: Giorgos Paraskevopoulos <geopar@central.ntua.gr>