### PR TITLE
Declare compatibility with Python 3.7+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description=long_description,
     author="Andreas Kloeckner",
     author_email="inform@tiker.net",
-    python_requires="~=3.6",
+    python_requires="~=3.7",
     install_requires=[
         "urwid>=1.1.1",
         "pygments>=2.7.4",


### PR DESCRIPTION
Fixes #480. Version 2021.2 now requires the use of `dataclasses` which is present only in Python 3.7 and up.