### PR TITLE
Adjust setup.py so that "pip install" pulls in the dataclasses package on Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     ],
     test_requires=[
         "pytest>=2",
-        "dataclasses>=0.7;python_version<='3.6'"
     ],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         "pygments>=2.7.4",
         "jedi>=0.18,<1",
         "urwid_readline",
-	"dataclasses>=0.7;python_version<='3.6'",
+        "dataclasses>=0.7;python_version<='3.6'",
     ],
     test_requires=[
         "pytest>=2",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
         "urwid>=1.1.1",
         "pygments>=2.7.4",
         "jedi>=0.18,<1",
-        "urwid_readline"
+        "urwid_readline",
+	"dataclasses>=0.7;python_version<='3.6'",
     ],
     test_requires=[
         "pytest>=2",


### PR DESCRIPTION
Tested this fix by making the change to setup.py, then using `python3 -m build` to build the .whl file and finally used `pip install` on that file inside of a Python 3.6 virtual environment to show that it pulled in the dataclasses package. After the installation, using PuDB to run a Python script worked as expected.

```
~/$ python3.6 -m venv test_pudb
~/$ source test_pudb/bin/activate
(test_pudb) ~/$ python -m pip install pudb-2021.2.1-py3-none-any.whl
Looking in indexes: http://<internal_company_pypi_proxy>/artifactory/api/pypi/python-package-index/simple
Looking in links: http://<internal_company_pypi_proxy>
Processing ./pudb-2021.2.1-py3-none-any.whl
Collecting urwid>=1.1.1 (from pudb==2021.2.1)
Collecting jedi<1,>=0.18 (from pudb==2021.2.1)
  Using cached https://<internal_company_pypi_proxy>/packages/packages/f9/36/7aa67ae2663025b49e8426ead0bad983fee1b73f472536e9790655da0277/jedi-0.18.0-py2.py3-none-any.whl
Collecting urwid-readline (from pudb==2021.2.1)
Collecting dataclasses>=0.7; python_version <= "3.6" (from pudb==2021.2.1)
  Downloading https://<internal_company_pypi_proxy>/packages/packages/fe/ca/75fac5856ab5cfa51bbbcefa250182e50441074fdc3f803f6e76451fab43/dataclasses-0.8-py3-none-any.whl
Collecting pygments>=2.7.4 (from pudb==2021.2.1)
  Using cached https://<internal_company_pypi_proxy>/packages/packages/78/c8/8d9be2f72d8f465461f22b5f199c04f7ada933add4dae6e2468133c17471/Pygments-2.10.0-py3-none-any.whl
Collecting parso<0.9.0,>=0.8.0 (from jedi<1,>=0.18->pudb==2021.2.1)
  Using cached https://<internal_company_pypi_proxy>/packages/packages/a9/c4/d5476373088c120ffed82f34c74b266ccae31a68d665b837354d4d8dc8be/parso-0.8.2-py2.py3-none-any.whl
Installing collected packages: urwid, parso, jedi, urwid-readline, dataclasses, pygments, pudb
Successfully installed dataclasses-0.8 jedi-0.18.0 parso-0.8.2 pudb-2021.2.1 pygments-2.10.0 urwid-2.1.2 urwid-readline-0.13
(test_pudb) ~/$ cat test.py
print("hello, world!")
(test_pudb) ~/$ python -m pudb test.py
hello, world!
(test_pudb)
```