### PR TITLE
Prefer packaging for determining versions

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1692,8 +1692,12 @@ class DebuggerUI(FrameVarInfoKeeper):
                         "command line error")
                 return
 
+            try:
+                from packaging.version import parse as LooseVersion     # noqa: N812
+            except ImportError:
+                from distutils.version import LooseVersion
+
             import jedi
-            from distutils.version import LooseVersion
             if LooseVersion(jedi.__version__) < LooseVersion("0.16.0"):
                 self.add_cmdline_content(
                         "jedi 0.16.0 is required for Tab completion",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setup(
         "pygments>=2.7.4",
         "jedi>=0.18,<1",
         "urwid_readline",
-        "dataclasses>=0.7;python_version<='3.6'",
+        "packaging>=20.0",
+        "dataclasses>=0.7;python_version<'3.7'",
     ],
     test_requires=[
         "pytest>=2",


### PR DESCRIPTION
All of `distutils` is deprecated now and this `packaging` thing seems to be what people are porting to (from a quick search).