### PR TITLE
Miscellaneous touchups in the var view

### DIFF
--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -464,6 +464,8 @@ def get_stringifier(iinfo: InspectInfo) -> Callable:
     try:
         return STRINGIFIERS[iinfo.display_type]
     except KeyError:
+        if "" == iinfo.display_type.strip():
+            return lambda _: "ERROR: custom stringifier is not set"
         try:
             if not custom_stringifier_dict:  # Only execfile once
                 from os.path import expanduser, expandvars

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -42,8 +42,6 @@ try:
 except ImportError:
     HAVE_NUMPY = 0
 
-ELLIPSIS = "…"
-
 BASIC_TYPES = []
 BASIC_TYPES.append(type(None))
 BASIC_TYPES.append(int)
@@ -493,9 +491,6 @@ def get_stringifier(iinfo: InspectInfo) -> Callable:
 # {{{ tree walking
 
 class ValueWalker(ABC):
-    NUM_PREVIEW_ITEMS = 3
-    MAX_PREVIEW_ITEM_LEN = 16
-
     EMPTY_LABEL = "<empty>"
     CONTINUATION_LABEL = "[...]"
 

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -31,7 +31,7 @@ import inspect
 import warnings
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sized
 from typing import Tuple, List
 from pudb.lowlevel import ui_log
 from pudb.ui_tools import text_width
@@ -428,8 +428,8 @@ def default_stringifier(value):
         if isinstance(result, str):
             return str(result)
 
-    elif type(value) in [set, frozenset, list, tuple, dict]:
-        return "%s (%s)" % (type(value).__name__, len(value))
+    elif isinstance(value, Sized):
+        return f"{type(value).__name__} ({len(value)})"
 
     return str(type(value).__name__)
 

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -42,12 +42,13 @@ try:
 except ImportError:
     HAVE_NUMPY = 0
 
-BASIC_TYPES = []
-BASIC_TYPES.append(type(None))
-BASIC_TYPES.append(int)
-BASIC_TYPES.append(str)
-BASIC_TYPES.extend((float, complex))
-BASIC_TYPES = tuple(BASIC_TYPES)
+BASIC_TYPES = (
+    type(None),
+    int,
+    str,
+    float,
+    complex,
+)
 
 # }}}
 

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -485,7 +485,7 @@ def get_stringifier(iinfo: InspectInfo) -> Callable:
                              "named pudb_stringifier at the module level.")
                 return lambda value: str(
                         "ERROR: Invalid custom stringifier file: "
-                        "pudb_stringifer not defined.")
+                        "pudb_stringifier not defined.")
             else:
                 return (lambda value:
                     str(custom_stringifier_dict["pudb_stringifier"](value)))

--- a/pudb/var_view.py
+++ b/pudb/var_view.py
@@ -42,14 +42,6 @@ try:
 except ImportError:
     HAVE_NUMPY = 0
 
-BASIC_TYPES = (
-    type(None),
-    int,
-    str,
-    float,
-    complex,
-)
-
 # }}}
 
 
@@ -216,24 +208,6 @@ class WatchEvalError:
 # }}}
 
 
-# {{{ safe types
-
-def get_str_safe_types():
-    import types
-
-    return tuple(getattr(types, s) for s in
-        "BuiltinFunctionType BuiltinMethodType  ClassType "
-        "CodeType FileType FrameType FunctionType GetSetDescriptorType "
-        "LambdaType MemberDescriptorType MethodType ModuleType "
-        "SliceType TypeType TracebackType UnboundMethodType XRangeType".split()
-        if hasattr(types, s)) + (WatchEvalError,)
-
-
-STR_SAFE_TYPES = get_str_safe_types()
-
-# }}}
-
-
 # {{{ widget
 
 class VariableWidget(urwid.FlowWidget):
@@ -393,7 +367,33 @@ class VariableWidget(urwid.FlowWidget):
 # }}}
 
 
-custom_stringifier_dict = {}
+# {{{ stringifiers
+
+BASIC_TYPES = (
+    type(None),
+    int,
+    str,
+    float,
+    complex,
+)
+
+
+# {{{ safe types
+
+def get_str_safe_types():
+    import types
+
+    return tuple(getattr(types, s) for s in
+        "BuiltinFunctionType BuiltinMethodType  ClassType "
+        "CodeType FileType FrameType FunctionType GetSetDescriptorType "
+        "LambdaType MemberDescriptorType MethodType ModuleType "
+        "SliceType TypeType TracebackType UnboundMethodType XRangeType".split()
+        if hasattr(types, s)) + (WatchEvalError,)
+
+
+STR_SAFE_TYPES = get_str_safe_types()
+
+# }}}
 
 
 def default_stringifier(value):
@@ -446,6 +446,8 @@ def error_stringifier(_):
     return "ERROR: Invalid custom stringifier file."
 
 
+custom_stringifier_dict = {}
+
 STRINGIFIERS = {
     "default": default_stringifier,
     "type": type_stringifier,
@@ -487,6 +489,8 @@ def get_stringifier(iinfo: InspectInfo) -> Callable:
             else:
                 return (lambda value:
                     str(custom_stringifier_dict["pudb_stringifier"](value)))
+
+# }}}
 
 
 # {{{ tree walking


### PR DESCRIPTION
This is several minor commits, feel free to take or leave whichever you're interested in!
- Various small bits of cleanup in `var_view.py`
- Give a specific error message if a user accidentally presses `c` in the var view when they don't have a custom stringifier set
- Show then length of all sized items, not just the builtin containers.