### PR TITLE
Add pytest-mock to test_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     ],
     test_requires=[
         "pytest>=2",
+        "pytest-mock",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
This is already in requirements-dev.txt but should be here as well as some of the unit tests fail to run without its `mocker` fixture.