### PR TITLE
Fix stack oddities

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -397,11 +397,13 @@ class Debugger(bdb.Bdb):
         else:
             tb = exc_tuple[2]
 
-        if frame is None and tb is not None:
-            frame = tb.tb_frame
+        if frame is None:
+            assert tb is not None
+            walk_frame = tb.tb_frame
+        else:
+            walk_frame = frame
 
         found_bottom_frame = False
-        walk_frame = frame
         while True:
             if walk_frame is self.bottom_frame:
                 found_bottom_frame = True
@@ -411,6 +413,7 @@ class Debugger(bdb.Bdb):
             walk_frame = walk_frame.f_back
 
         if not found_bottom_frame and not self.post_mortem:
+            # We aren't supposed to be debugging this.
             return
 
         self.stack, index = self.get_shortened_stack(frame, tb)

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -372,6 +372,8 @@ class Debugger(bdb.Bdb):
             self.set_frame_index(self.curindex+1)
 
     def get_shortened_stack(self, frame, tb):
+        if tb is not None:
+            frame = None
         stack, index = self.get_stack(frame, tb)
 
         for i, (s_frame, _lineno) in enumerate(stack):

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -2789,7 +2789,7 @@ class DebuggerUI(FrameVarInfoKeeper):
                 for bp in self._get_bp_list()]
 
     def update_stack(self):
-        def make_frame_ui(frame_lineno):
+        def make_frame_ui(i, frame_lineno):
             frame, lineno = frame_lineno
 
             code = frame.f_code
@@ -2804,11 +2804,12 @@ class DebuggerUI(FrameVarInfoKeeper):
                     ui_log.exception(message)
                     class_name = "!! %s !!" % message
 
-            return StackFrame(frame is self.debugger.curframe,
+            return StackFrame(i == self.debugger.curindex,
                     code.co_name, class_name,
                     self._format_fname(code.co_filename), lineno)
 
-        frame_uis = [make_frame_ui(fl) for fl in self.debugger.stack]
+        frame_uis = [make_frame_ui(i, fl)
+                for i, fl in enumerate(self.debugger.stack)]
         if CONFIG["current_stack_frame"] == "top":
             frame_uis = frame_uis[::-1]
         elif CONFIG["current_stack_frame"] == "bottom":


### PR DESCRIPTION
This fixes a few oddities about the stack window that have been irritating me for a while:

- In post-mortem mode, there were often two copies of the stack in the stack window, one from the backtrace and the other from the frame objects.
- Post-mortem stacks may contain the same frame twice (e.g. when an exception is caught and re-raised: once for the location of the exception in this frame, and once more for the handler). Thus: Identify stack frames by index, not frame object.