### PR TITLE
`pudb.run`: Expose version information

### DIFF
--- a/pudb/run.py
+++ b/pudb/run.py
@@ -1,9 +1,19 @@
 def main():
+    import os
     import sys
-
     import argparse
+
+    from pudb import VERSION
+
+    version_info = "pudb:%(prog)s v" + VERSION
+
+    if sys.argv[1:] == ["-v"]:
+        print(version_info % {"prog": os.path.basename(__file__)})
+        sys.exit(os.EX_OK)
+
     parser = argparse.ArgumentParser(
-        usage="%(prog)s [options] [-m] SCRIPT-OR-MODULE-TO-RUN [SCRIPT_ARGS]"
+        usage="%(prog)s [options] [-m] SCRIPT-OR-MODULE-TO-RUN [SCRIPT_ARGS]",
+        epilog=version_info
     )
     parser.add_argument("-s", "--steal-output", action="store_true"),
 
@@ -19,6 +29,7 @@ def main():
     parser.add_argument("--pre-run", metavar="COMMAND",
                         help="Run command before each program run",
                         default="")
+    parser.add_argument("--version", action="version", version=version_info)
     parser.add_argument("script_args", nargs=argparse.REMAINDER,
                         help="Arguments to pass to script or module")
 

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import os
+import pytest
+
+from pudb.run import main
+
+
+def csv(x):
+    return "('" + "', '".join(x) + "',)"
+
+
+main_version_scenarios = [
+    ("-v",),
+    ("--version",),
+    ("--version", "dont_look_at_me.py"),
+]
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [pytest.param(scenario, id=csv(scenario)) for scenario in main_version_scenarios],
+)
+def test_main_version(capsys, mocker, argv):
+    mocker.patch("sys.argv", [os.path.basename(main.__code__.co_filename), *argv])
+
+    with pytest.raises(SystemExit) as ex:
+        main()
+        assert ex.value == 0
+
+    captured = capsys.readouterr()
+
+    assert "pudb:run.py v" in captured.out
+
+
+def test_main_v_with_args(capsys, mocker):
+    """
+    This will fail, because args is not only ``-v``,
+    and that's reserved for future use ...
+    """
+    mocker.patch("sys.argv", [
+        os.path.basename(main.__code__.co_filename),
+        "-v",
+        "dont_look_at_me.py"
+    ])
+
+    with pytest.raises(SystemExit) as ex:
+        main()
+        assert ex.value == 2
+
+    captured = capsys.readouterr()
+
+    assert "error: unrecognized arguments: -v" in captured.err
+    assert not captured.out


### PR DESCRIPTION
Calling `python -m pudb.run -v` (**exactly!**), or using `--version` flag,
it prints the version information and exits.

Additionally, added tests to safeguard functionality.

Fixes https://github.com/inducer/pudb/discussions/527

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>