### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/starting.rst
+++ b/doc/starting.rst
@@ -100,7 +100,7 @@ The following programming interface is available for the remote debugger:
 In "reverse" remote debugging, pudb connects to a socket, rather than listening to one.
 
 First open the socket and listen using the netcat(``nc``), as below.
-Netcat of couse is not a telnet client, so it can behave diffrently than a telnet client.
+Netcat of course is not a telnet client, so it can behave differently than a telnet client.
 By using the ```stty``` with "no echo: and "no buffering" input options, we
 can make a socket that nonetheless behave simillarly::
 

--- a/test/test_var_view.py
+++ b/test/test_var_view.py
@@ -145,8 +145,8 @@ def generate_containerlike_class():
 
 class BaseValueWalkerTestCase(unittest.TestCase):
     """
-    There are no actual tests defined in this class, it provides utitlities
-    useful for testing the variable view in variaous ways.
+    There are no actual tests defined in this class, it provides utilities
+    useful for testing the variable view in various ways.
     """
     EMPTY_ITEM = (ValueWalker.EMPTY_LABEL, None)
     MOD_STR = " [all+()]"
@@ -200,7 +200,7 @@ class BaseValueWalkerTestCase(unittest.TestCase):
         self.values_to_expand = [container]
         self.walker = BasicValueWalker(FrameVarInfoForTesting(expand_paths))
 
-        # Build out list of extected view contents according to container type.
+        # Build out list of expected view contents according to container type.
         expected = [(label, self.value_string(container))]
         if isinstance(container, PudbMapping):
             expected.extend([(f"[{repr(key)}]", repr(container[key]))


### PR DESCRIPTION
There are small typos in:
- doc/starting.rst
- test/test_var_view.py

Fixes:
- Should read `various` rather than `variaous`.
- Should read `utilities` rather than `utitlities`.
- Should read `expected` rather than `extected`.
- Should read `differently` rather than `diffrently`.
- Should read `course` rather than `couse`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md