### PR TITLE
Fix critical bug when re-entering IPython 8.0.0 (and later) external shell

### DIFF
--- a/pudb/shell.py
+++ b/pudb/shell.py
@@ -220,7 +220,14 @@ def run_ipython_shell_v11(globals, locals):
         args.append(banner)
     else:
         print(banner)
+
+    # XXX Quick and dirty way to prevent issues with IPython 8.4.0+, introduced by commit 08d54c0e367b535fd88aca5273fd09e5e70d08f8
+    # Setting this property will prevent call to IPython.core.interactiveshell.InteractiveShell._atexit_once()
+    # from inside IPython.terminal.interactiveshell.TerminalInteractiveShell.mainloop()
+    # This allows us to repeatedly re-call mainloop() and the whole run_ipython_shell_v11() function
+    shell._atexit_once_called = True
     shell.mainloop(*args)
+    del shell._atexit_once_called  # Unsetting property
 
     # Restore originating namespace
     _update_ipython_ns(shell, old_globals, old_locals)

--- a/pudb/shell.py
+++ b/pudb/shell.py
@@ -221,13 +221,16 @@ def run_ipython_shell_v11(globals, locals):
     else:
         print(banner)
 
-    # XXX Quick and dirty way to prevent issues with IPython 8.4.0+, introduced by commit 08d54c0e367b535fd88aca5273fd09e5e70d08f8
-    # Setting this property will prevent call to IPython.core.interactiveshell.InteractiveShell._atexit_once()
-    # from inside IPython.terminal.interactiveshell.TerminalInteractiveShell.mainloop()
-    # This allows us to repeatedly re-call mainloop() and the whole run_ipython_shell_v11() function
+    # XXX Quick and dirty way to fix issues with IPython 8.0.0+, introduced
+    # by commit 08d54c0e367b535fd88aca5273fd09e5e70d08f8.
+    # Setting _atexit_once_called = True will prevent call to
+    # IPython.core.interactiveshell.InteractiveShell._atexit_once() from inside
+    # IPython.terminal.interactiveshell.TerminalInteractiveShell.mainloop()
+    # This allows us to repeatedly re-call mainloop() and the whole
+    # run_ipython_shell_v11() function
     shell._atexit_once_called = True
     shell.mainloop(*args)
-    del shell._atexit_once_called  # Unsetting property
+    del shell._atexit_once_called
 
     # Restore originating namespace
     _update_ipython_ns(shell, old_globals, old_locals)


### PR DESCRIPTION
I've found a bug with recent IPython 8.0.0 shell, which disrupts my personal workflow. Opening the external IPython shell (via !) only works properly the first time, namespace gets disrupted afterwards. You can verify this by calling globals() within the IPython shell and comparing results after the first and second time you enter the shell.

Here's a little fix for this bug:
- IPython 8.0.0+ performs at-exit operations after calling mainloop
  (introduced by 08d54c0e367b535fd88aca5273fd09e5e70d08f8 commmit),
  breaking necessary PuDB functionality. This prevents re-entering
  IPython shell
- Quick fix sets/unsets internal shell._atexit_once_called property
  during run_ipython_shell_v11, preventing those operations from being
  executed