### PR TITLE
Get terminal size using os.get_terminal_size()

### DIFF
--- a/pudb/forked.py
+++ b/pudb/forked.py
@@ -1,6 +1,5 @@
 import sys
 import os
-import struct
 
 from pudb.debugger import Debugger
 

--- a/pudb/forked.py
+++ b/pudb/forked.py
@@ -1,6 +1,5 @@
 import sys
-import fcntl
-import termios
+import os
 import struct
 
 from pudb.debugger import Debugger
@@ -18,11 +17,8 @@ def set_trace(paused=True, frame=None, term_size=None):
     if term_size is None:
         try:
             # Getting terminal size
-            s = struct.unpack(
-                "hh",
-                fcntl.ioctl(1, termios.TIOCGWINSZ, "1234"),
-            )
-            term_size = (s[1], s[0])
+            s = os.get_terminal_size()
+            term_size = (s.columns, s.lines)
         except Exception:
             term_size = (80, 24)
 

--- a/pudb/remote.py
+++ b/pudb/remote.py
@@ -40,7 +40,6 @@ import errno
 import os
 import socket
 import sys
-import struct
 import atexit
 from typing import Callable, Any
 

--- a/pudb/remote.py
+++ b/pudb/remote.py
@@ -40,8 +40,6 @@ import errno
 import os
 import socket
 import sys
-import fcntl
-import termios
 import struct
 import atexit
 from typing import Callable, Any
@@ -118,8 +116,8 @@ class RemoteDebugger(Debugger):
 
         if term_size is None:
             try:
-                s = struct.unpack("hh", fcntl.ioctl(1, termios.TIOCGWINSZ, "1234"))
-                term_size = (s[1], s[0])
+                s = os.get_terminal_size()
+                term_size = (s.columns, s.lines)
             except Exception:
                 term_size = (80, 24)
 


### PR DESCRIPTION
Hi,

A small PR to swap out the usage of `fcntl` / `termios` with `os.get_terminal_size()`. 

I was hoping to try and help make `pudb` cross-platform, this looks like a first step :)


Thanks,
Eli