### PR TITLE
Generate zsh completion script automatically

### DIFF
--- a/pudb/run.py
+++ b/pudb/run.py
@@ -1,4 +1,4 @@
-def main():
+def get_argparse_parser():
     import os
     import sys
     import argparse
@@ -32,6 +32,13 @@ def main():
     parser.add_argument("--version", action="version", version=version_info)
     parser.add_argument("script_args", nargs=argparse.REMAINDER,
                         help="Arguments to pass to script or module")
+    return parser
+
+
+def main(**kwargs):
+    import sys
+
+    parser = get_argparse_parser()
 
     options = parser.parse_args()
     args = options.script_args

--- a/scripts/zsh_completion.in
+++ b/scripts/zsh_completion.in
@@ -1,0 +1,5 @@
+#compdef {{programs}}
+
+_arguments -s -S \
+  {{flags}} \
+  '*:file:_files'

--- a/scripts/zsh_completion.py
+++ b/scripts/zsh_completion.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+import os
+from os.path import dirname as dirn
+import sys
+import re
+from setuptools import find_packages
+from argparse import SUPPRESS
+from typing import Final
+
+path = dirn(dirn((os.path.abspath(__file__))))
+sys.path.insert(0, path)
+from pudb.run import get_argparse_parser
+
+PACKAGES: Final = find_packages(path)
+PACKAGE: Final = PACKAGES[0]
+BINNAME: Final = "pudb3"
+ZSH_COMPLETION_FILE: Final = "_" + BINNAME
+ZSH_COMPLETION_TEMPLATE: Final = os.path.join(
+    dirn(os.path.abspath(__file__)), "zsh_completion.in"
+)
+pat_class = re.compile("'(.*)'")
+
+flags = []
+for action in get_argparse_parser()._actions:
+    if len(action.option_strings) > 1:
+        optionstr = "{" + ",".join(action.option_strings) + "}"
+    elif len(action.option_strings) == 1:
+        optionstr = action.option_strings[0]
+    else:
+        optionstr = ""
+    if action.dest in ["help", "version"]:
+        prefix = "'(- *)'"
+    else:
+        prefix = ""
+
+    if action.help == SUPPRESS:
+        helpstr = ""
+    elif action.help:
+        helpstr = action.help.replace("]", "\\]").replace("'", "'\\''")
+    else:
+        helpstr = ""
+    if optionstr == "":
+        flag = "'(-)1"
+    else:
+        flag = "{0}{1}'[{2}]".format(prefix, optionstr, helpstr)
+    if action.metavar is None and optionstr == "":
+        action.metavar = action.dest
+    if isinstance(action.metavar, str):
+        completion = ":" + action.metavar.replace(":", "\\:")
+        action.metavar = action.metavar.lower()
+        if action.metavar == "file":
+            completion += ":_files"
+        elif action.metavar == "script_args":
+            completion += ":_files -g *.py"
+        elif action.metavar == "dir":
+            completion += ":_dirs"
+        elif action.metavar == "url":
+            completion += ":_urls"
+    elif isinstance(action.default, bool) or action.default == SUPPRESS:
+        completion = ""
+    else:
+        completion = ":" + pat_class.findall(str(action.default.__class__))[0]
+    if action.choices:
+        completion += ":(" + " ".join(action.choices) + ")"
+    flags += ["{0}{1}'".format(flag, completion)]
+
+with open(ZSH_COMPLETION_TEMPLATE) as f:
+    template = f.read()
+
+template = template.replace("{{programs}}", BINNAME)
+template = template.replace("{{flags}}", " \\\n  ".join(flags))
+
+with open(ZSH_COMPLETION_FILE, "w") as f:
+    f.write(template)


### PR DESCRIPTION
Fix #540

Modified from <https://github.com/ytdl-org/youtube-dl/tree/master/devscripts>

`/usr/share/zsh/site-functions/_pudb3`
```zsh
#compdef pudb3

_arguments -s -S \
  '(- *)'{-h,--help}'[show this help message and exit]:str' \
  {-s,--steal-output}'[]' \
  {-m,--module}'[Debug as module or package instead of as a script]' \
  {-le,--log-errors}'[Log internal errors to the given file]:FILE' \
  --pre-run'[Run command before each program run]:COMMAND' \
  '(- *)'--version'[show program'\''s version number and exit]:str' \
  '*:script_args:_files'
```

```
❯ pudb3 -<Tab>
option
--help           show this help message and exit
-h               show this help message and exit
-le              Log internal errors to the given file
--log-errors     Log internal errors to the given file
-m               Debug as module or package instead of as a script
--module         Debug as module or package instead of as a script
--pre-run        Run command before each program run
-s
--steal-output
--version        show program's version number and exit
❯ pudb3 <Tab>
script_args
debug_me.py           examples/             MANIFEST.in           pudb/                 requirements.dev.txt  setup.py              try-the-debugger.sh*
doc/                  LICENSE               manual-tests/         README.rst            setup.cfg             test/
```