### PR TITLE
Fix zsh completion of `--pre-run`

### DIFF
--- a/pudb/run.py
+++ b/pudb/run.py
@@ -1,4 +1,4 @@
-COMMAND = {"zsh": "_command_names -e"}
+COMMAND = {"zsh": "{_command_names -e}"}
 PREAMBLE = {
     "zsh": """\
 _script_args() {
@@ -23,10 +23,11 @@ def get_argparse_parser():
     version_info = "pudb:%(prog)s v" + VERSION
 
     if sys.argv[1:] == ["-v"]:
-        print(version_info % {"prog": os.path.basename(__file__)})
+        print(version_info % {"prog": "pudb3"})
         sys.exit(os.EX_OK)
 
     parser = argparse.ArgumentParser(
+        "pudb3",
         usage="%(prog)s [options] [-m] SCRIPT-OR-MODULE-TO-RUN [SCRIPT_ARGS]",
         epilog=version_info
     )

--- a/pudb/run.py
+++ b/pudb/run.py
@@ -20,14 +20,14 @@ def get_argparse_parser():
 
     from pudb import VERSION
 
-    version_info = "pudb:%(prog)s v" + VERSION
+    version_info = "%(prog)s v" + VERSION
 
     if sys.argv[1:] == ["-v"]:
-        print(version_info % {"prog": "pudb3"})
+        print(version_info % {"prog": "pudb"})
         sys.exit(os.EX_OK)
 
     parser = argparse.ArgumentParser(
-        "pudb3",
+        "pudb",
         usage="%(prog)s [options] [-m] SCRIPT-OR-MODULE-TO-RUN [SCRIPT_ARGS]",
         epilog=version_info
     )

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     entry_points={
         "console_scripts": [
             # Deprecated. Should really use python -m pudb.
-            "pudb3 = pudb.run:main",
+            "pudb = pudb.run:main",
             ],
         "gui_script": [],
     },

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -30,7 +30,7 @@ def test_main_version(capsys, mocker, argv):
 
     captured = capsys.readouterr()
 
-    assert "pudb:pudb3 v" in captured.out
+    assert "pudb v" in captured.out
 
 
 def test_main_v_with_args(capsys, mocker):

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -30,7 +30,7 @@ def test_main_version(capsys, mocker, argv):
 
     captured = capsys.readouterr()
 
-    assert "pudb:run.py v" in captured.out
+    assert "pudb:pudb3 v" in captured.out
 
 
 def test_main_v_with_args(capsys, mocker):


### PR DESCRIPTION
Refer https://github.com/zsh-users/zsh/blob/master/Completion/Unix/Command/_sudo#L47-L51
the original completion of `--pre-run` will complete external commands, environment variables, built-in functions of zsh, etc.
Now it only complete external commands, which is expected result of `--pre-run`: it cannot run built-in functions of shell.
