### PR TITLE
Implement "--continue" CLI arg (alias "-c")

### DIFF
--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -106,8 +106,8 @@ def runmodule(*args, **kwargs):
 
 
 def runscript(mainpyfile, args=None, pre_run="", steal_output=False,
-              run_as_module=False):
-    dbg = _get_debugger(steal_output=steal_output)
+              _continue=False, run_as_module=False):
+    dbg = _get_debugger(steal_output=steal_output, _continue=_continue)
 
     # Note on saving/restoring sys.argv: it's a good idea when sys.argv was
     # modified by the script being debugged. It's a bad idea when it was

--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -106,8 +106,8 @@ def runmodule(*args, **kwargs):
 
 
 def runscript(mainpyfile, args=None, pre_run="", steal_output=False,
-              _continue=False, run_as_module=False):
-    dbg = _get_debugger(steal_output=steal_output, _continue=_continue)
+              _continue_at_start=False, run_as_module=False):
+    dbg = _get_debugger(steal_output=steal_output, _continue_at_start=_continue_at_start)
 
     # Note on saving/restoring sys.argv: it's a good idea when sys.argv was
     # modified by the script being debugged. It's a bad idea when it was

--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -107,7 +107,10 @@ def runmodule(*args, **kwargs):
 
 def runscript(mainpyfile, args=None, pre_run="", steal_output=False,
               _continue_at_start=False, run_as_module=False):
-    dbg = _get_debugger(steal_output=steal_output, _continue_at_start=_continue_at_start)
+    dbg = _get_debugger(
+        steal_output=steal_output,
+        _continue_at_start=_continue_at_start,
+    )
 
     # Note on saving/restoring sys.argv: it's a good idea when sys.argv was
     # modified by the script being debugged. It's a bad idea when it was

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -183,7 +183,7 @@ class Debugger(bdb.Bdb):
     _current_debugger = []
 
     def __init__(self, stdin=None, stdout=None, term_size=None, steal_output=False,
-                 _continue=False, **kwargs):
+                 _continue_at_start=False, **kwargs):
 
         if Debugger._current_debugger:
             raise ValueError("a Debugger instance already exists")
@@ -193,7 +193,7 @@ class Debugger(bdb.Bdb):
         bdb.Bdb.__init__(self, **kwargs)
         self.ui = DebuggerUI(self, stdin=stdin, stdout=stdout, term_size=term_size)
         self.steal_output = steal_output
-        self._continue = _continue
+        self._continue_at_start__setting = _continue_at_start
 
         self.setup_state()
 
@@ -305,7 +305,7 @@ class Debugger(bdb.Bdb):
         self.bottom_frame = None
         self.mainpyfile = ""
         self._wait_for_mainpyfile = False
-        self._continue_at_start = self._continue
+        self._continue_at_start = self._continue_at_start__setting
         self.current_bp = None
         self.post_mortem = False
         # Mapping of (filename, lineno) to bool. If True, will stop on the

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -444,16 +444,8 @@ class Debugger(bdb.Bdb):
         if "__exc_tuple__" in frame.f_locals:
             del frame.f_locals["__exc_tuple__"]
 
-        if self._wait_for_mainpyfile:
-            if (self.mainpyfile != self.canonic(frame.f_code.co_filename)
-                    or frame.f_lineno <= 0):
-                return
-            self._wait_for_mainpyfile = False
-            self.bottom_frame = frame
-            if self._continue_at_start:
-                self._continue_at_start = False
-                self.set_continue()
-                return
+        if self._waiting_for_mainpyfile(frame):
+            return
 
         if self.get_break(self.canonic(frame.f_code.co_filename), frame.f_lineno):
             self.current_bp = (
@@ -472,19 +464,24 @@ class Debugger(bdb.Bdb):
         if frame.f_code.co_name != "<module>":
             frame.f_locals["__return__"] = return_value
 
+        if self._waiting_for_mainpyfile(frame):
+            return
+
+        if "__exc_tuple__" not in frame.f_locals:
+            self.interaction(frame)
+
+    def _waiting_for_mainpyfile(self, frame):
         if self._wait_for_mainpyfile:
             if (self.mainpyfile != self.canonic(frame.f_code.co_filename)
                     or frame.f_lineno <= 0):
-                return
+                return True
             self._wait_for_mainpyfile = False
             self.bottom_frame = frame
             if self._continue_at_start:
                 self._continue_at_start = False
                 self.set_continue()
-                return
-
-        if "__exc_tuple__" not in frame.f_locals:
-            self.interaction(frame)
+                return True
+        return False
 
     def user_exception(self, frame, exc_tuple):
         """This function is called if an exception occurs,

--- a/pudb/run.py
+++ b/pudb/run.py
@@ -32,8 +32,8 @@ def get_argparse_parser():
         epilog=version_info
     )
     shtab.add_argument_to(parser, preamble=PREAMBLE)
-    # dest="_continue" needed as "continue" is a python keyword
-    parser.add_argument("-c", "--continue", action="store_true", dest="_continue")
+    # dest="_continue_at_start" needed as "continue" is a python keyword
+    parser.add_argument("-c", "--continue", action="store_true", dest="_continue_at_start")
     parser.add_argument("-s", "--steal-output", action="store_true")
 
     # note: we're implementing -m as a boolean flag, mimicking pdb's behavior,
@@ -71,7 +71,7 @@ def main(**kwargs):
     options_kwargs = {
         "pre_run": options.pre_run,
         "steal_output": options.steal_output,
-        "_continue": options._continue,
+        "_continue_at_start": options._continue_at_start,
     }
 
     if len(args) < 1:

--- a/pudb/run.py
+++ b/pudb/run.py
@@ -33,7 +33,12 @@ def get_argparse_parser():
     )
     shtab.add_argument_to(parser, preamble=PREAMBLE)
     # dest="_continue_at_start" needed as "continue" is a python keyword
-    parser.add_argument("-c", "--continue", action="store_true", dest="_continue_at_start")
+    parser.add_argument(
+        "-c", "--continue",
+        action="store_true",
+        dest="_continue_at_start",
+        help="Let the script run until an exception occurs or a breakpoint is hit",
+    )
     parser.add_argument("-s", "--steal-output", action="store_true")
 
     # note: we're implementing -m as a boolean flag, mimicking pdb's behavior,

--- a/pudb/run.py
+++ b/pudb/run.py
@@ -32,7 +32,9 @@ def get_argparse_parser():
         epilog=version_info
     )
     shtab.add_argument_to(parser, preamble=PREAMBLE)
-    parser.add_argument("-s", "--steal-output", action="store_true"),
+    # dest="_continue" needed as "continue" is a python keyword
+    parser.add_argument("-c", "--continue", action="store_true", dest="_continue")
+    parser.add_argument("-s", "--steal-output", action="store_true")
 
     # note: we're implementing -m as a boolean flag, mimicking pdb's behavior,
     # and makes it possible without much fuss to support cases like:
@@ -69,6 +71,7 @@ def main(**kwargs):
     options_kwargs = {
         "pre_run": options.pre_run,
         "steal_output": options.steal_output,
+        "_continue": options._continue,
     }
 
     if len(args) < 1:


### PR DESCRIPTION
Adds a `--continue` (alias `-c`) CLI option. To my knowledge we don't have a command language like `pdb` does, so I thought it would be simpler to go about supporting this feature this way, as oppose to a generic `-c` like `pdb` offers. Alternatively I suppose we could call the keyboard controls a "command language" and try to find a way feed a series of keyboard inputs through.