### PR TITLE
Added key binding: toggle_cmdline_focus

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -68,3 +68,4 @@ Overriding default key bindings
     hotkeys_code = C
     hotkeys_stack = S
     hotkeys_variables = V
+    hotkeys_toggle_cmdline_focus = ctrl x

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -88,7 +88,7 @@ Keys:
 
 Shell-related:
     ! - open the external shell (configured in the settings)
-    Ctrl-x - toggle the internal shell focus
+    {CONFIG["hotkeys_toggle_cmdline_focus"]} - toggle the internal shell focus
 
     +/- - grow/shrink inline shell (active in command line history)
     _/= - minimize/maximize inline shell (active in command line history)
@@ -869,7 +869,8 @@ class DebuggerUI(FrameVarInfoKeeper):
                 ])
 
         self.cmdline_pile = urwid.Pile([
-            ("flow", urwid.Text("Command line: [Ctrl-X]")),
+            ("flow", urwid.Text(
+                f"Command line: [{CONFIG['hotkeys_toggle_cmdline_focus']}]")),
             ("weight", 1, urwid.AttrMap(self.cmdline_list, "command line output")),
             ("flow", self.cmdline_edit_bar),
             ])
@@ -1878,7 +1879,7 @@ class DebuggerUI(FrameVarInfoKeeper):
         self.cmdline_edit_sigwrap.listen("ctrl p", cmdline_history_prev)
         self.cmdline_edit_sigwrap.listen("esc", toggle_cmdline_focus)
 
-        self.top.listen("ctrl x", toggle_cmdline_focus)
+        self.top.listen(CONFIG["hotkeys_toggle_cmdline_focus"], toggle_cmdline_focus)
 
         # {{{ command line sizing
         def set_cmdline_default_size(weight):

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -118,6 +118,7 @@ def load_config():
     conf_dict.setdefault("hotkeys_variables", "V")
     conf_dict.setdefault("hotkeys_stack", "S")
     conf_dict.setdefault("hotkeys_breakpoints", "B")
+    conf_dict.setdefault("hotkeys_toggle_cmdline_focus", "ctrl x")
 
     def normalize_bool_inplace(name):
         try:
@@ -263,7 +264,8 @@ def edit_config(ui, conf_dict):
             bool(conf_dict["prompt_on_quit"]), on_state_change=_update_config,
                 user_data=("prompt_on_quit", None))
 
-    hide_cmdline_win = urwid.CheckBox("Hide command line (Ctrl-X) window "
+    hide_cmdline_win = urwid.CheckBox("Hide command line",
+            f"({conf_dict['hotkeys_toggle_cmdline_focus']}) window "
                                       "when not in use",
             bool(conf_dict["hide_cmdline_win"]), on_state_change=_update_config,
                 user_data=("hide_cmdline_win", None))


### PR DESCRIPTION
Make below configurable:

Action: **toggle_cmdline_focus**: 
Default binding: `ctrl x`