### PR TITLE
Fix extra comma breaking settings display

### DIFF
--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -264,7 +264,7 @@ def edit_config(ui, conf_dict):
             bool(conf_dict["prompt_on_quit"]), on_state_change=_update_config,
                 user_data=("prompt_on_quit", None))
 
-    hide_cmdline_win = urwid.CheckBox("Hide command line",
+    hide_cmdline_win = urwid.CheckBox("Hide command line"
             f"({conf_dict['hotkeys_toggle_cmdline_focus']}) window "
                                       "when not in use",
             bool(conf_dict["hide_cmdline_win"]), on_state_change=_update_config,


### PR DESCRIPTION
This extra comma was causing the following traceback when trying to open the settings:

```
Traceback (most recent call last):
  File "/Users/mvanderkamp/projects/pudb/pudb/debugger.py", line 2753, in event_loop
    toplevel.keypress(self.size, k)
  File "/Users/mvanderkamp/projects/pudb/pudb/ui_tools.py", line 124, in keypress
    return handler(self, size, key)
  File "/Users/mvanderkamp/projects/pudb/pudb/debugger.py", line 2141, in do_edit_config
    self.run_edit_config()
  File "/Users/mvanderkamp/projects/pudb/pudb/debugger.py", line 2287, in run_edit_config
    edit_config(self, CONFIG)
  File "/Users/mvanderkamp/projects/pudb/pudb/settings.py", line 267, in edit_config
    hide_cmdline_win = urwid.CheckBox("Hide command line",
  File "/opt/homebrew/lib/python3.10/site-packages/urwid/wimp.py", line 159, in __init__
    self.set_state(state)
  File "/opt/homebrew/lib/python3.10/site-packages/urwid/wimp.py", line 237, in set_state
    repr(self), repr(state)))
  File "/opt/homebrew/lib/python3.10/site-packages/urwid/widget.py", line 583, in __repr__
    return split_repr(self)
  File "/opt/homebrew/lib/python3.10/site-packages/urwid/split_repr.py", line 56, in split_repr
    words = self._repr_words()
  File "/opt/homebrew/lib/python3.10/site-packages/urwid/wimp.py", line 162, in _repr_words
    return self.__super._repr_words() + [
  File "/opt/homebrew/lib/python3.10/site-packages/urwid/widget.py", line 587, in _repr_words
    if self.selectable():
  File "/opt/homebrew/lib/python3.10/site-packages/urwid/widget.py", line 1764, in <lambda>
    selectable = property(lambda self:get_delegate(self).selectable)
AttributeError: 'NoneType' object has no attribute 'selectable'
```