### PR TITLE
Handle cyclic import in _have_debugger()

### DIFF
--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -91,8 +91,12 @@ def _get_debugger(**kwargs):
 
 
 def _have_debugger():
-    from pudb.debugger import Debugger
-    return bool(Debugger._current_debugger)
+    try:
+        from pudb.debugger import Debugger
+        return bool(Debugger._current_debugger)
+    except ImportError:
+        # Import cycles may happen if function is called during early startup
+        return False
 
 
 import signal  # noqa


### PR DESCRIPTION
This function may cause an import cycle when it is called during early startup.
Specifically, during import of debugger.py, the settings are loaded. Exceptions during load are forwarded to the logging system, where they are handled by TerminalOrStreamHandler. This is turn will call _have_debugger() to determine whether to display an UI dialog. The function attempts to import the debugger.py, completing the import cycle.

sample traceback:
```
Traceback (most recent call last):
  File "pudb/settings.py", line 128, in normalize_bool_inplace
    raise Exception
Exception

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "pudb/run.py", line 112, in <module>
    main()
  File "pudb/run.py", line 108, in main
    runscript(mainpyfile, **options_kwargs)
  File "pudb/__init__.py", line 110, in runscript
    dbg = _get_debugger(
  File "pudb/__init__.py", line 75, in _get_debugger
    from pudb.debugger import Debugger
  File "pudb/debugger.py", line 40, in <module>
    CONFIG = load_config()
  File "pudb/settings.py", line 136, in load_config
    normalize_bool_inplace("line_numbers")
  File "pudb/settings.py", line 134, in normalize_bool_inplace
    settings_log.exception("Failed to process config")
  File "/usr/lib/python3.10/logging/__init__.py", line 1512, in exception
    self.error(msg, *args, exc_info=exc_info, **kwargs)
  File "/usr/lib/python3.10/logging/__init__.py", line 1506, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/usr/lib/python3.10/logging/__init__.py", line 1624, in _log
    self.handle(record)
  File "/usr/lib/python3.10/logging/__init__.py", line 1634, in handle
    self.callHandlers(record)
  File "/usr/lib/python3.10/logging/__init__.py", line 1696, in callHandlers
    hdlr.handle(record)
  File "/usr/lib/python3.10/logging/__init__.py", line 968, in handle
    self.emit(record)
  File "pudb/lowlevel.py", line 61, in emit
    elif _have_debugger():
  File "pudb/__init__.py", line 94, in _have_debugger
    from pudb.debugger import Debugger
ImportError: cannot import name 'Debugger' from partially initialized module 'pudb.debugger' (most likely due to a circular import) (pudb/debugger.py)
```