### PR TITLE
Cmdline history: deque, restore input command, ability to use up/down arrow keys

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1863,6 +1863,7 @@ Error with jump. Note that jumping only works on the topmost stack frame.
                 self.cmdline_history.append(cmd)
 
             self.cmdline_history_position = -1
+            self.cmdline_saved_edit_text = ""
 
             prev_sys_stdin = sys.stdin
             prev_sys_stdout = sys.stdout

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -96,7 +96,7 @@ Shell-related:
     _/= - minimize/maximize inline shell (active in command line history)
 
     Ctrl-v - insert newline
-    Ctrl-n/p - browse command history or clear/recall prompt
+    Ctrl-n/p, Arrow down/up - browse command history or clear/recall prompt
     Tab - yes, there is (simple) tab completion
 """
 
@@ -1961,6 +1961,8 @@ Error with jump. Note that jumping only works on the topmost stack frame.
         self.cmdline_edit_sigwrap.listen("tab", cmdline_tab_complete)
         self.cmdline_edit_sigwrap.listen("ctrl v", cmdline_append_newline)
         self.cmdline_edit_sigwrap.listen("enter", cmdline_exec)
+        self.cmdline_edit_sigwrap.listen("down", cmdline_history_next)
+        self.cmdline_edit_sigwrap.listen("up", cmdline_history_prev)
         self.cmdline_edit_sigwrap.listen("ctrl n", cmdline_history_next)
         self.cmdline_edit_sigwrap.listen("ctrl p", cmdline_history_prev)
         self.cmdline_edit_sigwrap.listen("esc", toggle_cmdline_focus)

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -97,6 +97,7 @@ Shell-related:
 
     Ctrl-v - insert newline
     Ctrl-n/p, Arrow down/up - browse command history or clear/recall prompt
+    Shift-Page down/up - browse in the results scrollback
     Tab - yes, there is (simple) tab completion
 """
 

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -92,8 +92,8 @@ Shell-related:
     ! - open the external shell (configured in the settings)
     {CONFIG["hotkeys_toggle_cmdline_focus"]} - toggle the internal shell focus
 
-    +/- - grow/shrink inline shell (active in command line history)
-    _/= - minimize/maximize inline shell (active in command line history)
+    +/- - grow/shrink inline shell (active in results scrollback)
+    _/= - minimize/maximize inline shell (active in results scrollback)
 
     Ctrl-v - insert newline
     Ctrl-n/p, Arrow down/up - browse command history or clear/recall prompt

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -1999,10 +1999,16 @@ Error with jump. Note that jumping only works on the topmost stack frame.
                 weight /= 1.25
                 set_cmdline_default_size(weight)
 
+        def cmdline_results_scroll(w, size, key):
+            size = self.cmdline_pile.get_item_size(size, 1, True)
+            self.cmdline_list.keypress(size, key.lstrip("shift "))
+
         self.cmdline_sigwrap.listen("=", max_cmdline)
         self.cmdline_sigwrap.listen("+", grow_cmdline)
         self.cmdline_sigwrap.listen("_", min_cmdline)
         self.cmdline_sigwrap.listen("-", shrink_cmdline)
+        for key in ("page up", "page down"):
+            self.cmdline_sigwrap.listen("shift " + key, cmdline_results_scroll)
 
         # }}}
 


### PR DESCRIPTION
This PR aims to change three things related to the internal command line history:
- **using `collections.deque` for the history storage**: This handles the maximum size internally, automatically deleting old entries on `append()`
  I just found a deque a nice fit for the use case while working on the other features, but there is no absolute need for this change.
- **Restore command line input when browsing history**: See commit messages and in-code comments for detailed explanation
  This fixes one of my pain points in pudb: When accidentally hitting Ctrl-N in the command line, it deletes my potentially long command input with no possibility to get it back.
- **Using up/down arrow keys for browsing history**: This is not implemented yet as I want to ask how I should implement this. Is adding a boolean config option fine that enables this?
  This is my other pain point in the pudb internal shell: After not being aware for a year that browsing the history is even possible, I still find Ctrl-N/P highly unfamiliar despite using pudb for multiple years now. I still press the arrow keys now and then.