### PR TITLE
Added setting to hide the header

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -2841,7 +2841,7 @@ Error with jump. Note that jumping only works on the topmost stack frame.
                 (None, " "),
                 ("header warning", "[POST-MORTEM MODE]")
                 ])
-            self.update_header(override=True)
+            self.show_header()
             CONFIG["hide_header"] = False
 
         elif exc_tuple is not None:
@@ -2849,7 +2849,7 @@ Error with jump. Note that jumping only works on the topmost stack frame.
                 (None, " "),
                 ("header warning", "[PROCESSING EXCEPTION - hit 'e' to examine]")
                 ])
-            self.update_header(override=True)
+            self.show_header()
             CONFIG["hide_header"] = False
 
 
@@ -2965,10 +2965,13 @@ Error with jump. Note that jumping only works on the topmost stack frame.
     def update_cmdline_win(self):
         self.set_cmdline_state(not CONFIG["hide_cmdline_win"])
         
-    def update_header(self, override=None):
-        if override is not None:
-            self.top._w.header = self.header if override else None
+    def update_header(self):
+        """Update the header to reflect the current settings."""
         self.top._w.header = self.header if not CONFIG["hide_header"] else None
+
+    def show_header(self):
+        """Show the header."""
+        self.top._w.header = self.header
 
     # }}}
 

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -947,14 +947,14 @@ class DebuggerUI(FrameVarInfoKeeper):
                             self.rhs_col_sigwrap),
                         ],
                     dividechars=1)
-        
+
         background = urwid.AttrMap(self.columns, "background")
 
         self.caption = urwid.Text("")
         self.header = urwid.AttrMap(self.caption, "header")
-        
+
         self.top = SignalWrap(urwid.Frame(background, self.header))
-        
+
         if CONFIG["hide_header"]:
             self.top._w.header = None
 
@@ -2423,7 +2423,7 @@ Error with jump. Note that jumping only works on the topmost stack frame.
                 width=("relative", 75),
                 height=("relative", 75),
                 )
-        
+
         w = Attr(w, "background")
 
         return self.event_loop(w)[0]
@@ -2852,7 +2852,6 @@ Error with jump. Note that jumping only works on the topmost stack frame.
             self.show_header()
             CONFIG["hide_header"] = False
 
-
         self.caption.set_text(caption)
         self.event_loop()
 
@@ -2964,7 +2963,7 @@ Error with jump. Note that jumping only works on the topmost stack frame.
 
     def update_cmdline_win(self):
         self.set_cmdline_state(not CONFIG["hide_cmdline_win"])
-        
+
     def update_header(self):
         """Update the header to reflect the current settings."""
         self.top._w.header = self.header if not CONFIG["hide_header"] else None

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -947,14 +947,16 @@ class DebuggerUI(FrameVarInfoKeeper):
                             self.rhs_col_sigwrap),
                         ],
                     dividechars=1)
+        
+        background = urwid.AttrMap(self.columns, "background")
 
         self.caption = urwid.Text("")
-        header = urwid.AttrMap(self.caption, "header")
-        self.top = SignalWrap(urwid.Frame(
-            urwid.AttrMap(self.columns, "background"),
-            header))
-
-        # }}}
+        self.header = urwid.AttrMap(self.caption, "header")
+        
+        self.top = SignalWrap(urwid.Frame(background, self.header))
+        
+        if CONFIG["hide_header"]:
+            self.top._w.header = None
 
         def change_rhs_box(name, index, direction, w, size, key):
             from pudb.settings import save_config
@@ -2421,6 +2423,7 @@ Error with jump. Note that jumping only works on the topmost stack frame.
                 width=("relative", 75),
                 height=("relative", 75),
                 )
+        
         w = Attr(w, "background")
 
         return self.event_loop(w)[0]
@@ -2838,11 +2841,17 @@ Error with jump. Note that jumping only works on the topmost stack frame.
                 (None, " "),
                 ("header warning", "[POST-MORTEM MODE]")
                 ])
+            self.update_header(override=True)
+            CONFIG["hide_header"] = False
+
         elif exc_tuple is not None:
             caption.extend([
                 (None, " "),
                 ("header warning", "[PROCESSING EXCEPTION - hit 'e' to examine]")
                 ])
+            self.update_header(override=True)
+            CONFIG["hide_header"] = False
+
 
         self.caption.set_text(caption)
         self.event_loop()
@@ -2955,6 +2964,11 @@ Error with jump. Note that jumping only works on the topmost stack frame.
 
     def update_cmdline_win(self):
         self.set_cmdline_state(not CONFIG["hide_cmdline_win"])
+        
+    def update_header(self, override=None):
+        if override is not None:
+            self.top._w.header = self.header if override else None
+        self.top._w.header = self.header if not CONFIG["hide_header"] else None
 
     # }}}
 

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -112,6 +112,7 @@ def load_config():
     conf_dict.setdefault("prompt_on_quit", "True")
 
     conf_dict.setdefault("hide_cmdline_win", "False")
+    conf_dict.setdefault("hide_header", "False")
 
     # hotkeys
     conf_dict.setdefault("hotkeys_code", "C")
@@ -133,6 +134,7 @@ def load_config():
     normalize_bool_inplace("wrap_variables")
     normalize_bool_inplace("prompt_on_quit")
     normalize_bool_inplace("hide_cmdline_win")
+    normalize_bool_inplace("hide_header")
 
     _config_[0] = conf_dict
     return conf_dict
@@ -178,6 +180,9 @@ def edit_config(ui, conf_dict):
 
     def _update_hide_cmdline_win():
         ui.update_cmdline_win()
+        
+    def _update_hide_header():
+        ui.update_header()
 
     def _update_current_stack_frame():
         ui.update_stack()
@@ -221,6 +226,11 @@ def edit_config(ui, conf_dict):
             new_conf_dict["hide_cmdline_win"] = not check_box.get_state()
             conf_dict.update(new_conf_dict)
             _update_hide_cmdline_win()
+            
+        elif option == "hide_header":
+            new_conf_dict["hide_header"] = not check_box.get_state()
+            conf_dict.update(new_conf_dict)
+            _update_hide_header()
 
         elif option == "current_stack_frame":
             # only activate if the new state of the radio button is 'on'
@@ -269,6 +279,10 @@ def edit_config(ui, conf_dict):
                                       "when not in use",
             bool(conf_dict["hide_cmdline_win"]), on_state_change=_update_config,
                 user_data=("hide_cmdline_win", None))
+    
+    hide_header = urwid.CheckBox("Hide header from top of window",
+            bool(conf_dict["hide_header"]), on_state_change=_update_config,
+                user_data=("hide_header", None))
 
     # {{{ shells
 
@@ -441,6 +455,7 @@ def edit_config(ui, conf_dict):
             + [cb_line_numbers]
             + [cb_prompt_on_quit]
             + [hide_cmdline_win]
+            + [hide_header]
 
             + [urwid.AttrMap(urwid.Text("\nShell:\n"), "group head")]
             + [shell_info]

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -180,7 +180,7 @@ def edit_config(ui, conf_dict):
 
     def _update_hide_cmdline_win():
         ui.update_cmdline_win()
-        
+
     def _update_hide_header():
         ui.update_header()
 
@@ -226,7 +226,7 @@ def edit_config(ui, conf_dict):
             new_conf_dict["hide_cmdline_win"] = not check_box.get_state()
             conf_dict.update(new_conf_dict)
             _update_hide_cmdline_win()
-            
+
         elif option == "hide_header":
             new_conf_dict["hide_header"] = not check_box.get_state()
             conf_dict.update(new_conf_dict)
@@ -279,7 +279,7 @@ def edit_config(ui, conf_dict):
                                       "when not in use",
             bool(conf_dict["hide_cmdline_win"]), on_state_change=_update_config,
                 user_data=("hide_cmdline_win", None))
-    
+
     hide_header = urwid.CheckBox("Hide header from top of window",
             bool(conf_dict["hide_header"]), on_state_change=_update_config,
                 user_data=("hide_header", None))


### PR DESCRIPTION
Now you see it
![image](https://github.com/inducer/pudb/assets/18319621/3202d711-a98e-4665-bfec-0a0ba8b2a747)

![image](https://github.com/inducer/pudb/assets/18319621/8b48c2ad-0947-4a50-8576-e434a51beffb)
![image](https://github.com/inducer/pudb/assets/18319621/75e24734-36ae-4a5e-af27-702cba990b43)

![image](https://github.com/inducer/pudb/assets/18319621/3ff95a9c-33ab-46a6-9e89-e74f922ce17f)

Now you don't

In reference to this issue 
https://github.com/inducer/pudb/issues/542