### PR TITLE
Exclude "test" from installed packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "Topic :: Terminals",
         "Topic :: Utilities",
     ],
-    packages=find_packages(),
+    packages=find_packages(exclude=["test"]),
     entry_points={
         "console_scripts": [
             # Deprecated. Should really use python -m pudb.


### PR DESCRIPTION
Fix `setup.py` not to install the `test` directory as a top-level package, i.e. as:

    /usr/lib/python3.11/site-packages/test