### PR TITLE
Add restart hotkey

### DIFF
--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -172,6 +172,10 @@ def runscript(mainpyfile, args=None, pre_run="", steal_output=False,
             import urwid
             pre_run_edit = urwid.Edit("", pre_run)
 
+            if dbg.restart_requested():
+                dbg.clear_restart()
+                break
+
             if not load_config()["prompt_on_quit"]:
                 return
 


### PR DESCRIPTION
It's useful to be able to restart debugging session quickly without using `q` command and selecting `<Restart>` from the UI.
It also remove the need to have `Prompt before quitting` enabled so `pudb` can be closed faster as well.