### PR TITLE
Add PUDB_RDB_REVERSE var to control reverse mode

### DIFF
--- a/doc/starting.rst
+++ b/doc/starting.rst
@@ -131,6 +131,11 @@ Specify host and port in set_trace and set the *reverse* parameter to *True*::
     from pudb.remote import set_trace
     set_trace(reverse=True)
 
+The "reverse" mode can also be enabled by setting the environment variable to a
+non-empty value (the keyword argument has priority over the env var)::
+
+    export PUDB_RDB_REVERSE=1
+
 Then watch the debugger connect to netcat::
 
     pudb:9999: Now in session with 127.0.0.1:6899.

--- a/pudb/remote.py
+++ b/pudb/remote.py
@@ -45,13 +45,15 @@ from typing import Callable, Any
 
 from pudb.debugger import Debugger
 
-__all__ = ["PUDB_RDB_HOST", "PUDB_RDB_PORT", "default_port", "debugger", "set_trace",
+__all__ = ["PUDB_RDB_HOST", "PUDB_RDB_PORT", "PUDB_RDB_REVERSE",
+           "default_port", "debugger", "set_trace",
            "debug_remote_on_single_rank"]
 
 default_port = 6899
 
 PUDB_RDB_HOST = os.environ.get("PUDB_RDB_HOST") or "127.0.0.1"
 PUDB_RDB_PORT = int(os.environ.get("PUDB_RDB_PORT") or default_port)
+PUDB_RDB_REVERSE = bool(os.environ.get("PUDB_RDB_REVERSE"))
 
 #: Holds the currently active debugger.
 _current = [None]
@@ -124,7 +126,7 @@ class RemoteDebugger(Debugger):
         port_search_limit=100,
         out=sys.stdout,
         term_size=None,
-        reverse=False,
+        reverse=PUDB_RDB_REVERSE,
     ):
         """
         :arg term_size: A two-tuple ``(columns, rows)``, or *None*. If *None*,
@@ -245,7 +247,9 @@ class RemoteDebugger(Debugger):
         self.say(SESSION_ENDED.format(self=self))
 
 
-def debugger(term_size=None, host=PUDB_RDB_HOST, port=PUDB_RDB_PORT, reverse=False):
+def debugger(
+        term_size=None, host=PUDB_RDB_HOST, port=PUDB_RDB_PORT, reverse=PUDB_RDB_REVERSE
+):
     """Return the current debugger instance (if any),
     or creates a new one."""
     rdb = _current[0]
@@ -258,7 +262,7 @@ def debugger(term_size=None, host=PUDB_RDB_HOST, port=PUDB_RDB_PORT, reverse=Fal
 
 
 def set_trace(
-    frame=None, term_size=None, host=PUDB_RDB_HOST, port=PUDB_RDB_PORT, reverse=False
+    frame=None, term_size=None, host=PUDB_RDB_HOST, port=PUDB_RDB_PORT, reverse=PUDB_RDB_REVERSE
 ):
     """Set breakpoint at current location, or a specified frame"""
     if frame is None:

--- a/pudb/remote.py
+++ b/pudb/remote.py
@@ -248,7 +248,10 @@ class RemoteDebugger(Debugger):
 
 
 def debugger(
-        term_size=None, host=PUDB_RDB_HOST, port=PUDB_RDB_PORT, reverse=PUDB_RDB_REVERSE
+    term_size=None,
+    host=PUDB_RDB_HOST,
+    port=PUDB_RDB_PORT,
+    reverse=PUDB_RDB_REVERSE
 ):
     """Return the current debugger instance (if any),
     or creates a new one."""
@@ -262,7 +265,11 @@ def debugger(
 
 
 def set_trace(
-    frame=None, term_size=None, host=PUDB_RDB_HOST, port=PUDB_RDB_PORT, reverse=PUDB_RDB_REVERSE
+    frame=None,
+    term_size=None,
+    host=PUDB_RDB_HOST,
+    port=PUDB_RDB_PORT,
+    reverse=PUDB_RDB_REVERSE
 ):
     """Set breakpoint at current location, or a specified frame"""
     if frame is None:


### PR DESCRIPTION
A follow-up PR to #629. 

A user can enable reverse debugging mode by setting the `PUDB_RDB_REVERSE` env var. This is useful when the debugger is invoked via `breakpoint()` ([PEP 553](https://peps.python.org/pep-0553/)) and there are multiple breakpoints