### PR TITLE
fix: macOS PUDB_TTY "I/O operation on closed file."

### DIFF
--- a/pudb/__init__.py
+++ b/pudb/__init__.py
@@ -80,7 +80,6 @@ def _get_debugger(**kwargs):
             kwargs.setdefault("stdin", tty_file)
             kwargs.setdefault("stdout", tty_file)
             kwargs.setdefault("term_size", term_size)
-            tty_file.close()
 
         from pudb.debugger import Debugger
         dbg = Debugger(**kwargs)


### PR DESCRIPTION
Don't close a file that's in use.
Apparently linux is okay with this, but macos isn't?

Otherwise, I get this error:

```
Traceback (most recent call last):
  File ".../site-packages/pudb/debugger.py", line 2542, in call_with_ui
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File ".../site-packages/pudb/debugger.py", line 2865, in interaction
    self.event_loop()
  File ".../site-packages/pudb/debugger.py", line 2821, in event_loop
    self.screen.draw_screen(self.size, canvas)
  File ".../site-packages/urwid/display/_raw_display_base.py", line 582, in draw_screen
    self._setup_G1()
  File ".../site-packages/urwid/display/_raw_display_base.py", line 524, in _setup_G1
    self.write(escape.DESIGNATE_G1_SPECIAL)
  File ".../site-packages/urwid/display/_raw_display_base.py", line 220, in write
    self._term_output_file.write(data)
ValueError: I/O operation on closed file.
```