### PR TITLE
Catch IndexError on empty Variables state

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -994,9 +994,12 @@ class DebuggerUI(FrameVarInfoKeeper):
             return None
 
         def change_var_state(w, size, key):
-            pos = self.var_list._w.focus_position
-            var = self.var_list._w.focus
+            try:
+                pos = self.var_list._w.focus_position
+            except IndexError:
+                return
 
+            var = self.var_list._w.focus
             if var is None:
                 return
 


### PR DESCRIPTION
## To reproduce:
1. `bash try-the-debugger.sh`
2. Go to the variables pane while it is still empty
3. Press `m` or any other command that would ordinarily modify how a variable is displayed.

<details>
<summary>Traceback</summary>

```python
python version: 3.11.9 (main, Apr  2 2024, 08:25:04) [Clang 15.0.0 (clang-1500.3.9.4)]
pudb version: 2024.1
urwid version: 2...6...1.2
Traceback (most recent call last):
  File "/Users/mvanderkamp/projects/pudb/pudb/debugger.py", line 2843, in event_loop
    toplevel.keypress(self.size, k)
  File "/Users/mvanderkamp/projects/pudb/pudb/ui_tools.py", line 131, in keypress
    result = self._w.keypress(size, key)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvanderkamp/projects/pudb/venv/lib/python3.11/site-packages/urwid/widget/frame.py", line 526, in keypress
    return self.body.keypress((maxcol, remaining), key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvanderkamp/projects/pudb/venv/lib/python3.11/site-packages/urwid/widget/widget.py", line 729, in keypress
    return get_delegate(self).keypress(size, key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvanderkamp/projects/pudb/venv/lib/python3.11/site-packages/urwid/widget/columns.py", line 1216, in keypress
    key = w.keypress(size_args[i], key)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvanderkamp/projects/pudb/pudb/ui_tools.py", line 131, in keypress
    result = self._w.keypress(size, key)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvanderkamp/projects/pudb/venv/lib/python3.11/site-packages/urwid/widget/pile.py", line 921, in keypress
    key = self.focus.keypress(size_args[i], key)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvanderkamp/projects/pudb/venv/lib/python3.11/site-packages/urwid/widget/widget.py", line 729, in keypress
    return get_delegate(self).keypress(size, key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvanderkamp/projects/pudb/venv/lib/python3.11/site-packages/urwid/widget/pile.py", line 921, in keypress
    key = self.focus.keypress(size_args[i], key)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvanderkamp/projects/pudb/venv/lib/python3.11/site-packages/urwid/widget/widget.py", line 729, in keypress
    return get_delegate(self).keypress(size, key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvanderkamp/projects/pudb/pudb/ui_tools.py", line 136, in keypress
    return handler(self, size, key)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvanderkamp/projects/pudb/pudb/debugger.py", line 997, in change_var_state
    pos = self.var_list._w.focus_position
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mvanderkamp/projects/pudb/venv/lib/python3.11/site-packages/urwid/widget/listbox.py", line 907, in _get_focus_position
    raise IndexError("No focus_position, ListBox is empty")
IndexError: No focus_position, ListBox is empty
```

</details>

## The fix
Check for an `IndexError` when reading `focus_position`. From urwid:
> property focus_position
the position of child widget in focus. The valid values for this position depend on the list walker in use. IndexError will be raised by reading this property when the ListBox is empty or setting this property to an invalid position.