### PR TITLE
Fix startup when no write permissions

### DIFF
--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -49,7 +49,10 @@ def get_save_config_path():
         return None
 
     path = os.path.join(XDG_CONFIG_HOME, XDG_CONF_RESOURCE)
-    os.makedirs(path, mode=0o700, exist_ok=True)
+    try:
+        os.makedirs(path, mode=0o700, exist_ok=True)
+    except Exception:
+        settings_log.exception("Failed to make config dir")
 
     return path
 


### PR DESCRIPTION
Making the parent directories of the config file could cause an exception if the process doesn't have write permissions. This is common with remote debugging in containers. Catch exceptions, log, and continue, same as other parts of the settings that cannot raise exceptions. The next stage of saving the config file will also fail, but this is already caught.