### PR TITLE
Fix compatibility with Python 3.13

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -456,7 +456,7 @@ class Debugger(bdb.Bdb):
         if self._waiting_for_mainpyfile(frame):
             return
 
-        if "__exc_tuple__" not in frame.f_locals:
+        if "__exception__" not in frame.f_locals:
             self.interaction(frame)
 
     def _waiting_for_mainpyfile(self, frame):
@@ -472,13 +472,15 @@ class Debugger(bdb.Bdb):
                 return True
         return False
 
-    def user_exception(self, frame, exc_tuple):
+    def user_exception(self, frame, exc_info):
         """This function is called if an exception occurs,
         but only if we are to stop at or just below this level."""
-        frame.f_locals["__exc_tuple__"] = exc_tuple
+
+        exc_type, exc_value, _exc_traceback = exc_info
+        frame.f_locals["__exception__"] = exc_type, exc_value
 
         if not self._wait_for_mainpyfile:
-            self.interaction(frame, exc_tuple)
+            self.interaction(frame, exc_info)
 
     # {{{ entrypoints
 

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -433,9 +433,6 @@ class Debugger(bdb.Bdb):
 
     def user_line(self, frame):
         """This function is called when we stop or break at this line."""
-        if "__exc_tuple__" in frame.f_locals:
-            del frame.f_locals["__exc_tuple__"]
-
         if self._waiting_for_mainpyfile(frame):
             return
 

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -227,33 +227,6 @@ class Debugger(bdb.Bdb):
             self._tty_file.close()
             self._tty_file = None
 
-    # These (dispatch_line and set_continue) are copied from bdb with the
-    # patch from https://bugs.python.org/issue16482 applied. See
-    # https://github.com/inducer/pudb/pull/90.
-    def dispatch_line(self, frame):
-        if self.stop_here(frame) or self.break_here(frame):
-            self.user_line(frame)
-            if self.quitting:
-                raise bdb.BdbQuit
-            # Do not re-install the local trace when we are finished debugging,
-            # see issues 16482 and 7238.
-            if not sys.gettrace():
-                return None
-        return self.trace_dispatch
-
-    def set_continue(self):
-        # Don't stop except at breakpoints or when finished
-        self._set_stopinfo(self.botframe, None, -1)
-        if not self.breaks:
-            # no breakpoints; run without debugger overhead
-            sys.settrace(None)
-            frame = sys._getframe().f_back
-            while frame:
-                del frame.f_trace
-                if frame is self.botframe:
-                    break
-                frame = frame.f_back
-
     def set_jump(self, frame, line):
         frame.f_lineno = line
 


### PR DESCRIPTION
This fixes a few issues I've noticed with Python 3.13, which seems to contain quite a few changes to `bdb`. This seems to work for me, but I'm not necessarily confident in these changes. See the commit messages for some explanation.

I would love some testing from others before I release this.

@asmeurer @mvanderkamp Would you be willing to give this a look/test?