### PR TITLE
RFC single key press to end "show output"

### DIFF
--- a/nonbufferedconsole.py
+++ b/nonbufferedconsole.py
@@ -1,0 +1,66 @@
+"""
+Evaluation script for non-buffered console operation and the portability
+of the implementation across Python supported platforms. Can be executed
+on any computer that has Python available. Does not depend on 3rd party
+libraries, exclusively uses core features.
+"""
+
+_nbc_use_input = True
+_nbc_use_getch = False
+_nbc_use_select = False
+
+import sys
+if sys.platform in ("emscripten", "wasi"):
+	pass
+elif sys.platform in ("win32",):
+	import msvcrt
+	_nbc_use_input = False
+	_nbc_use_getch = True
+else:
+	import select
+	import termios
+	import tty
+	_nbc_use_input = False
+	_nbc_use_select = True
+
+class NonBufferedConsole(object):
+
+	def __init__(self):
+		pass
+
+	def __enter__(self):
+		if _nbc_use_select:
+			self.prev_settings = termios.tcgetattr(sys.stdin)
+			tty.setcbreak(sys.stdin.fileno())
+		return self
+
+	def __exit__(self, type, value, traceback):
+		if _nbc_use_select:
+			termios.tcsetattr(sys.stdin, termios.TCSADRAIN, self.prev_settings)
+
+	def get_data(self):
+		if _nbc_use_getch:
+			c = msvcrt.getch()
+			if c in ('\x00', '\xe0'):
+				c = msvcrt.getch()
+			return c
+
+		if _nbc_use_select:
+			rset, _, _ = select.select([sys.stdin], [], [], None)
+			if sys.stdin in rset:
+				return sys.stdin.read(1)
+			return None
+
+		# The Python input() call strictly speaking is not a
+		# terminal in non-buffered mode and without a prompt.
+		# But supporting this fallback here is most appropriate
+		# and simplifies call sites.
+		if _nbc_use_input:
+			input("Hit Enter to return:")
+		return None
+
+if __name__ == "__main__":
+	print("waiting for key press")
+	with NonBufferedConsole() as nbc:
+		key = nbc.get_data()
+	print("key press seen")

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -765,6 +765,7 @@ class DirectSourceCodeProvider(SourceCodeProvider):
 
 # }}}
 
+
 # Local helper to get single key presses from a terminal in unbuffered
 # mode. Eliminates the necessity to press ENTER before other input also
 # becomes available.
@@ -784,13 +785,14 @@ class NonBufferedConsole(object):
         termios.tcsetattr(sys.stdin, termios.TCSADRAIN, self.prev_settings)
 
     def get_data(self):
-        rset, wset, eset = select.select([ sys.stdin, ], [], [], None)
+        rset, _, _ = select.select([sys.stdin], [], [], None)
         if sys.stdin in rset:
             return sys.stdin.read(1)
         return None
 
+
 class StoppedScreen:
-    def __init__(self, screen, show_output = None):
+    def __init__(self, screen, show_output=None):
         self.screen = screen
         self.single_key = bool(show_output)
 
@@ -816,6 +818,7 @@ class StoppedScreen:
         # The default behaviour, requires pressing ENTER.
         # Also the fall through for unmigrated configurations.
         input("Hit Enter to return:")
+
 
 class DebuggerUI(FrameVarInfoKeeper):
     # {{{ constructor

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -27,7 +27,10 @@ THE SOFTWARE.
 import bdb
 import gc
 import os
+import select
 import sys
+import termios
+import tty
 from collections import deque
 from functools import partial
 from itertools import count
@@ -762,17 +765,78 @@ class DirectSourceCodeProvider(SourceCodeProvider):
 
 # }}}
 
+class NonBlockingConsole(object):
+
+    def __init__(self, timeout = 0):
+        self.timeout = timeout
+
+    def __enter__(self):
+        self.old_settings = termios.tcgetattr(sys.stdin)
+        tty.setcbreak(sys.stdin.fileno())
+        return self
+
+    def __exit__(self, type, value, traceback):
+        termios.tcsetattr(sys.stdin, termios.TCSADRAIN, self.old_settings)
+
+    def get_data(self):
+        rset, wset, eset = select.select([ sys.stdin, ], [], [], self.timeout)
+        if sys.stdin in rset:
+            return sys.stdin.read(1)
+        return None
 
 class StoppedScreen:
-    def __init__(self, screen):
+    def __init__(self, screen, show_output = None):
+        # print("config option: {}".format(show_output), flush = True, file = sys.stderr)
         self.screen = screen
+        self.show_output = show_output
+        if "single_key" in show_output:
+            show_output = self.show_output.replace("single_key", "")
+            self.with_prompt = "silent" not in show_output
+            show_output = show_output.replace("silent", "")
+            show_output = show_output.strip()
+            # TODO Alternatively pick key names from remaining bare words?
+            # Could be perceived as more intuitive by users.
+            self.term_keys = {
+                "o_space_enter": "o \n",
+                "any_key": None,
+                "enter_only": "\n",
+            }.get(show_output, None)
+        else:
+            self.show_output = "python_input"
 
     def __enter__(self):
         self.screen.stop()
+        return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self.screen.start()
 
+    def press_key_to_return(self):
+        if "single_key" in self.show_output:
+            # Locally modified behaviour.
+            # BEWARE! The urwid screen is stopped when this method
+            # executes. Curses calls are not available, neither are
+            # urwid widgets nor key event handlers. This is why the
+            # default activity is to invoke Python's input(3).
+            # That's why something non-portable is done, fiddling
+            # with terminal settings. Which get restored afterwards.
+            if self.with_prompt:
+                print("Hit a key to return ", end = "", flush = True)
+            with NonBlockingConsole(timeout = None) as nbc:
+                while True:
+                    key = nbc.get_data()
+                    if not self.term_keys:
+                        break
+                    if key in self.term_keys:
+                        break
+            if self.with_prompt:
+                print("")
+            return
+        # The default behaviour, requires pressing ENTER.
+        # Also the fall through for unmigrated configurations.
+        if "python_input" in self.show_output or not self.show_output:
+            input("Hit Enter to return:")
+            return
 
 class DebuggerUI(FrameVarInfoKeeper):
     # {{{ constructor
@@ -2082,8 +2146,8 @@ Error with jump. Note that jumping only works on the topmost stack frame.
         # {{{ top-level listeners
 
         def show_output(w, size, key):
-            with StoppedScreen(self.screen):
-                input("Hit Enter to return:")
+            with StoppedScreen(self.screen, CONFIG["show_output"]) as s:
+                s.press_key_to_return()
 
         def reload_breakpoints_and_redisplay():
             reload_breakpoints()

--- a/pudb/lowlevel.py
+++ b/pudb/lowlevel.py
@@ -283,4 +283,73 @@ def decode_lines(lines):
 
 # }}}
 
+
+# {{{ non-buffered console
+
+# TODO Put these under try/except and fall back to input() when neither
+# can be loaded? All modules are Python builtins, but there are platforms
+# like non-POSIX Unix systems and Webassembly which this implementation
+# may not cover. Can some platforms succeed to load yet fail to operate,
+# like Windows which only supports select() on socket type descriptors?
+_use_input = True
+_use_getch = False
+_use_select = False
+if sys.platform in ("emscripten", "wasi"):
+    pass
+elif sys.platform in ("win32", "cygwin"):
+    import msvcrt
+    _use_input = False
+    _use_getch = True
+else:
+    import select
+    import tty
+    import termios
+    _use_input = False
+    _use_select = True
+
+
+# Local helper to get single key presses from a terminal in unbuffered
+# mode. Eliminates the necessity to press ENTER before other input also
+# becomes available.
+# Is used in situations where urwid is disabled and curses calls are
+# not available. Platform dependent gathering of a single key press
+# without an echo to the console.
+class NonBufferedConsole(object):
+
+    def __init__(self):
+        pass
+
+    def __enter__(self):
+        if _use_select:
+            self.prev_settings = termios.tcgetattr(sys.stdin)
+            tty.setcbreak(sys.stdin.fileno())
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if _use_select:
+            termios.tcsetattr(sys.stdin, termios.TCSADRAIN, self.prev_settings)
+
+    def get_data(self):
+        if _use_getch:
+            c = msvcrt.getch()
+            if c in ('\x00', '\xe0'):
+                c = msvcrt.getch()
+            return c
+        if _use_select:
+            rset, _, _ = select.select([sys.stdin], [], [], None)
+            if sys.stdin in rset:
+                return sys.stdin.read(1)
+        # Strictly speaking putting the fallback here which requires
+        # pressing ENTER is not correct, this is the "non buffered"
+        # console support code. But it simplifies call sites. And is
+        # easy to tell by users because a prompt is provided. This is
+        # the most portable approach, and backwards compatible with
+        # earlier PuDB releases. May not even be conditional, just
+        # the fallback.
+        if _use_input:
+            input("Hit Enter to return:")
+        return None
+
+# }}}
+
 # vim: foldmethod=marker

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -113,7 +113,7 @@ def load_config():
     conf_dict.setdefault("display", "auto")
 
     conf_dict.setdefault("prompt_on_quit", "True")
-    conf_dict.setdefault("show_output", "python_input")
+    conf_dict.setdefault("output_any_key", "False")
 
     conf_dict.setdefault("hide_cmdline_win", "False")
 
@@ -136,6 +136,7 @@ def load_config():
     normalize_bool_inplace("line_numbers")
     normalize_bool_inplace("wrap_variables")
     normalize_bool_inplace("prompt_on_quit")
+    normalize_bool_inplace("output_any_key")
     normalize_bool_inplace("hide_cmdline_win")
 
     _config_[0] = conf_dict
@@ -180,6 +181,9 @@ def edit_config(ui, conf_dict):
     def _update_prompt_on_quit():
         pass
 
+    def _update_output_any_key():
+        pass
+
     def _update_hide_cmdline_win():
         ui.update_cmdline_win()
 
@@ -221,7 +225,10 @@ def edit_config(ui, conf_dict):
             conf_dict.update(new_conf_dict)
             _update_prompt_on_quit()
 
-# XXX need to handle "show_output" here?
+        elif option == "output_any_key":
+            new_conf_dict["output_any_key"] = not check_box.get_state()
+            conf_dict.update(new_conf_dict)
+            _update_output_any_key()
 
         elif option == "hide_cmdline_win":
             new_conf_dict["hide_cmdline_win"] = not check_box.get_state()
@@ -270,7 +277,9 @@ def edit_config(ui, conf_dict):
             bool(conf_dict["prompt_on_quit"]), on_state_change=_update_config,
                 user_data=("prompt_on_quit", None))
 
-# XXX need to handle "show_output" here?
+    cb_output_any_key = urwid.CheckBox("Any key press exits output screen",
+            bool(conf_dict["output_any_key"]), on_state_change=_update_config,
+                user_data=("output_any_key", None))
 
     hide_cmdline_win = urwid.CheckBox("Hide command line"
             f"({conf_dict['hotkeys_toggle_cmdline_focus']}) window "
@@ -448,6 +457,7 @@ def edit_config(ui, conf_dict):
             + [urwid.AttrMap(urwid.Text("General:\n"), "group head")]
             + [cb_line_numbers]
             + [cb_prompt_on_quit]
+            + [cb_output_any_key]
             + [hide_cmdline_win]
 
             + [urwid.AttrMap(urwid.Text("\nShell:\n"), "group head")]

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -113,7 +113,6 @@ def load_config():
     conf_dict.setdefault("display", "auto")
 
     conf_dict.setdefault("prompt_on_quit", "True")
-    conf_dict.setdefault("output_any_key", "False")
 
     conf_dict.setdefault("hide_cmdline_win", "False")
 
@@ -136,7 +135,6 @@ def load_config():
     normalize_bool_inplace("line_numbers")
     normalize_bool_inplace("wrap_variables")
     normalize_bool_inplace("prompt_on_quit")
-    normalize_bool_inplace("output_any_key")
     normalize_bool_inplace("hide_cmdline_win")
 
     _config_[0] = conf_dict
@@ -181,9 +179,6 @@ def edit_config(ui, conf_dict):
     def _update_prompt_on_quit():
         pass
 
-    def _update_output_any_key():
-        pass
-
     def _update_hide_cmdline_win():
         ui.update_cmdline_win()
 
@@ -224,11 +219,6 @@ def edit_config(ui, conf_dict):
             new_conf_dict["prompt_on_quit"] = not check_box.get_state()
             conf_dict.update(new_conf_dict)
             _update_prompt_on_quit()
-
-        elif option == "output_any_key":
-            new_conf_dict["output_any_key"] = not check_box.get_state()
-            conf_dict.update(new_conf_dict)
-            _update_output_any_key()
 
         elif option == "hide_cmdline_win":
             new_conf_dict["hide_cmdline_win"] = not check_box.get_state()
@@ -276,10 +266,6 @@ def edit_config(ui, conf_dict):
     cb_prompt_on_quit = urwid.CheckBox("Prompt before quitting",
             bool(conf_dict["prompt_on_quit"]), on_state_change=_update_config,
                 user_data=("prompt_on_quit", None))
-
-    cb_output_any_key = urwid.CheckBox("Any key press exits output screen",
-            bool(conf_dict["output_any_key"]), on_state_change=_update_config,
-                user_data=("output_any_key", None))
 
     hide_cmdline_win = urwid.CheckBox("Hide command line"
             f"({conf_dict['hotkeys_toggle_cmdline_focus']}) window "
@@ -457,7 +443,6 @@ def edit_config(ui, conf_dict):
             + [urwid.AttrMap(urwid.Text("General:\n"), "group head")]
             + [cb_line_numbers]
             + [cb_prompt_on_quit]
-            + [cb_output_any_key]
             + [hide_cmdline_win]
 
             + [urwid.AttrMap(urwid.Text("\nShell:\n"), "group head")]

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -113,6 +113,7 @@ def load_config():
     conf_dict.setdefault("display", "auto")
 
     conf_dict.setdefault("prompt_on_quit", "True")
+    conf_dict.setdefault("show_output", "python_input")
 
     conf_dict.setdefault("hide_cmdline_win", "False")
 
@@ -220,6 +221,8 @@ def edit_config(ui, conf_dict):
             conf_dict.update(new_conf_dict)
             _update_prompt_on_quit()
 
+# XXX need to handle "show_output" here?
+
         elif option == "hide_cmdline_win":
             new_conf_dict["hide_cmdline_win"] = not check_box.get_state()
             conf_dict.update(new_conf_dict)
@@ -266,6 +269,8 @@ def edit_config(ui, conf_dict):
     cb_prompt_on_quit = urwid.CheckBox("Prompt before quitting",
             bool(conf_dict["prompt_on_quit"]), on_state_change=_update_config,
                 user_data=("prompt_on_quit", None))
+
+# XXX need to handle "show_output" here?
 
     hide_cmdline_win = urwid.CheckBox("Hide command line"
             f"({conf_dict['hotkeys_toggle_cmdline_focus']}) window "


### PR DESCRIPTION
Adds new 'show_output' config option. Remains backwards compatible, uses Python's input(3) by default. Extends that to also accept single key presses when configured. Should increase usability when 'o' and SPACE are as acceptable as ENTER is, which is rather distant from 'o'.


You can tell how this started with a quick local hack. Then grew bigger fast when I considered upstreaming. Became a little monster by now. The commit message provides details on the approach, and lists issues of the current implementation. This PR is meant to gather feedback.

Lack of doc update and UI adjustment is the biggest drawback. Just tell me your preference for more or fewer options, maybe point out which places need adjustment as new options are introduced. And I will improve that v1 to make it more acceptable.

Remaining text is the one commit's message, for your reference.


Introduce the 'show_output' config option, pass its value from the debugger's .show_output() method to the StoppedScreen class. Default to the 'python_input' selection for backwards compatibility. Support 'single_key' as an alternative, which accepts additional optional keywords: 'silent' to not prompt for key presses, and several sets of terminating key presses like 'o_space_enter', 'enter_only', or 'any_key' to reduce behavioural changes from to earlier versions.

  show_output = python_input
  show_output = single_key
  show_output = single_key silent o_space_enter

In the absence of terminating key press specs, any key press leaves the output screen. The implementation uses Python select(3) which may not work with stdin on Windows. The StoppedScreen implementation lends itself to more keywords and other ways of getting user input if desired.

TODO
- Config file handling is incomplete. Implements the keyword and its default value, but lacks documentation and UI controls.
- Move NonBlockingConsole to a better location, common support or platform dependent?
- Drop diagnostics.
- Is it confusing to have too many configuration options? Just have "single key, any key" as one boolean choice while the default is the input(3) invocation that is portable to all platforms?
- Maybe adjust Python style where required.