### PR TITLE
debugger: leave output screen with single key press

### DIFF
--- a/.pylintrc-local.yml
+++ b/.pylintrc-local.yml
@@ -4,3 +4,4 @@
   - IPython
   - py.test
   - pytest
+  - msvcrt

--- a/nonbufferedconsole.py
+++ b/nonbufferedconsole.py
@@ -1,0 +1,66 @@
+"""
+Evaluation script for non-buffered console operation and the portability
+of the implementation across Python supported platforms. Can be executed
+on any computer that has Python available. Does not depend on 3rd party
+libraries, exclusively uses core features.
+"""
+
+_nbc_use_input = True
+_nbc_use_getch = False
+_nbc_use_select = False
+
+import sys
+if sys.platform in ("emscripten", "wasi"):
+	pass
+elif sys.platform in ("win32",):
+	import msvcrt
+	_nbc_use_input = False
+	_nbc_use_getch = True
+else:
+	import select
+	import termios
+	import tty
+	_nbc_use_input = False
+	_nbc_use_select = True
+
+class NonBufferedConsole(object):
+
+	def __init__(self):
+		pass
+
+	def __enter__(self):
+		if _nbc_use_select:
+			self.prev_settings = termios.tcgetattr(sys.stdin)
+			tty.setcbreak(sys.stdin.fileno())
+		return self
+
+	def __exit__(self, type, value, traceback):
+		if _nbc_use_select:
+			termios.tcsetattr(sys.stdin, termios.TCSADRAIN, self.prev_settings)
+
+	def get_data(self):
+		if _nbc_use_getch:
+			c = msvcrt.getch()
+			if c in ('\x00', '\xe0'):
+				c = msvcrt.getch()
+			return c
+
+		if _nbc_use_select:
+			rset, _, _ = select.select([sys.stdin], [], [], None)
+			if sys.stdin in rset:
+				return sys.stdin.read(1)
+			return None
+
+		# The Python input() call strictly speaking is not a
+		# terminal in non-buffered mode and without a prompt.
+		# But supporting this fallback here is most appropriate
+		# and simplifies call sites.
+		if _nbc_use_input:
+			input("Hit Enter to return:")
+		return None
+
+if __name__ == "__main__":
+	print("waiting for key press")
+	with NonBufferedConsole() as nbc:
+		key = nbc.get_data()
+	print("key press seen")

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -35,7 +35,7 @@ from types import TracebackType
 
 import urwid
 
-from pudb.lowlevel import decode_lines, ui_log
+from pudb.lowlevel import decode_lines, NonBufferedConsole, ui_log
 from pudb.settings import get_save_config_path, load_config, save_config
 
 
@@ -769,9 +769,14 @@ class StoppedScreen:
 
     def __enter__(self):
         self.screen.stop()
+        return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self.screen.start()
+
+    def press_key_to_return(self):
+        with NonBufferedConsole() as nbc:
+            key = nbc.get_data()
 
 
 class DebuggerUI(FrameVarInfoKeeper):
@@ -2082,8 +2087,8 @@ Error with jump. Note that jumping only works on the topmost stack frame.
         # {{{ top-level listeners
 
         def show_output(w, size, key):
-            with StoppedScreen(self.screen):
-                input("Hit Enter to return:")
+            with StoppedScreen(self.screen) as s:
+                s.press_key_to_return()
 
         def reload_breakpoints_and_redisplay():
             reload_breakpoints()

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -35,7 +35,7 @@ from types import TracebackType
 
 import urwid
 
-from pudb.lowlevel import decode_lines, ConsoleSingleKeyReader, ui_log
+from pudb.lowlevel import ConsoleSingleKeyReader, decode_lines, ui_log
 from pudb.settings import get_save_config_path, load_config, save_config
 
 

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -775,8 +775,8 @@ class StoppedScreen:
         self.screen.start()
 
     def press_key_to_return(self):
-        with ConsoleSingleKeyReader() as nbc:
-            key = nbc.get_single_key()
+        with ConsoleSingleKeyReader() as key_reader:
+            key = key_reader.get_single_key()
 
 
 class DebuggerUI(FrameVarInfoKeeper):

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -35,7 +35,7 @@ from types import TracebackType
 
 import urwid
 
-from pudb.lowlevel import decode_lines, NonBufferedConsole, ui_log
+from pudb.lowlevel import decode_lines, ConsoleSingleKeyReader, ui_log
 from pudb.settings import get_save_config_path, load_config, save_config
 
 
@@ -775,8 +775,8 @@ class StoppedScreen:
         self.screen.start()
 
     def press_key_to_return(self):
-        with NonBufferedConsole() as nbc:
-            key = nbc.get_data()
+        with ConsoleSingleKeyReader() as nbc:
+            key = nbc.get_single_key()
 
 
 class DebuggerUI(FrameVarInfoKeeper):

--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -776,7 +776,7 @@ class StoppedScreen:
 
     def press_key_to_return(self):
         with ConsoleSingleKeyReader() as key_reader:
-            key = key_reader.get_single_key()
+            key_reader.get_single_key()
 
 
 class DebuggerUI(FrameVarInfoKeeper):

--- a/pudb/lowlevel.py
+++ b/pudb/lowlevel.py
@@ -334,7 +334,7 @@ class ConsoleSingleKeyReader(object):
             # special keys (function keys, cursor, keypad) require
             # another call when the first returned '\0' or '\xe0'.
             c = msvcrt.getch()
-            if c in ('\x00', '\xe0'):
+            if c in ("\x00", "\xe0"):
                 c = msvcrt.getch()
             return c
 

--- a/pudb/lowlevel.py
+++ b/pudb/lowlevel.py
@@ -329,6 +329,10 @@ class ConsoleSingleKeyReader(object):
 
     def get_single_key(self):
         if _keyread_impl == _KEYREAD_IMPL_GETCH:
+            # https://docs.python.org/3/library/msvcrt.html#msvcrt.getch
+            # Most keys are returned in the first getch() call. Some
+            # special keys (function keys, cursor, keypad) require
+            # another call when the first returned '\0' or '\xe0'.
             c = msvcrt.getch()
             if c in ('\x00', '\xe0'):
                 c = msvcrt.getch()

--- a/pudb/lowlevel.py
+++ b/pudb/lowlevel.py
@@ -286,18 +286,18 @@ def decode_lines(lines):
 
 # {{{ get single key press from console outside of curses
 
-( _NBC_IMPL_INPUT, _NBC_IMPL_GETCH, _NBC_IMPL_SELECT, ) = range(3)
-_nbc_impl = _NBC_IMPL_INPUT
+( _KEYREAD_IMPL_INPUT, _KEYREAD_IMPL_GETCH, _KEYREAD_IMPL_SELECT, ) = range(3)
+_keyread_impl = _KEYREAD_IMPL_INPUT
 if sys.platform in ("emscripten", "wasi"):
     pass
 elif sys.platform in ("win32",):
     import msvcrt
-    _nbc_impl = _NBC_IMPL_GETCH
+    _keyread_impl = _KEYREAD_IMPL_GETCH
 else:
     import select
     import termios
     import tty
-    _nbc_impl = _NBC_IMPL_SELECT
+    _keyread_impl = _KEYREAD_IMPL_SELECT
 
 
 class ConsoleSingleKeyReader(object):
@@ -318,23 +318,23 @@ class ConsoleSingleKeyReader(object):
         pass
 
     def __enter__(self):
-        if _nbc_impl == _NBC_IMPL_SELECT:
+        if _keyread_impl == _KEYREAD_IMPL_SELECT:
             self.prev_settings = termios.tcgetattr(sys.stdin)
             tty.setcbreak(sys.stdin.fileno())
         return self
 
     def __exit__(self, type, value, traceback):
-        if _nbc_impl == _NBC_IMPL_SELECT:
+        if _keyread_impl == _KEYREAD_IMPL_SELECT:
             termios.tcsetattr(sys.stdin, termios.TCSADRAIN, self.prev_settings)
 
     def get_single_key(self):
-        if _nbc_impl == _NBC_IMPL_GETCH:
+        if _keyread_impl == _KEYREAD_IMPL_GETCH:
             c = msvcrt.getch()
             if c in ('\x00', '\xe0'):
                 c = msvcrt.getch()
             return c
 
-        elif _nbc_impl == _NBC_IMPL_SELECT:
+        elif _keyread_impl == _KEYREAD_IMPL_SELECT:
             rset, _, _ = select.select([sys.stdin], [], [], None)
             assert sys.stdin in rset
             return sys.stdin.read(1)


### PR DESCRIPTION
This is a cleaned up submission of the PR 673 essence. Implements transparent support for platform dependent single key press without a prompt, with Python core and without external dependencies. Supports all major desktop systems where you expect to run the debugger, falls back to the most portable backwards compatible behaviour on platforms that are known to not work with the single key approach. Does not involve config items, needs no documentation update. The implementation is considered both readable and maintainable, supporting more platforms is straight forward as they get identified. Thank you for the feedback which helped very much in getting to that state.
