### PR TITLE
Avoid crashing debugged program with a bdb.BdbQuit exception ☠️

### DIFF
--- a/pudb/debugger.py
+++ b/pudb/debugger.py
@@ -2298,7 +2298,7 @@ Error with jump. Note that jumping only works on the topmost stack frame.
         def quit(w, size, key):
             with open(self.cmdline_history_path, "w") as history:
                 history.write("\n".join(self.cmdline_history))
-            self.debugger.set_quit()
+            sys.settrace(None)
             end()
 
         def do_edit_config(w, size, key):


### PR DESCRIPTION
Finally got into using `pudb` for developing https://github.com/ranger/ranger/ but was annoyed by the crash everytime I wanted to quit the debugger.. wonder why this hasn't been reported before? but was happy the fix is so simple after diving into it a bit. Or do you think this is the wrong approach?
