### PR TITLE
fix: handle bool defaults in normalize_bool_inplace

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -12110,6 +12110,14 @@
                 }
             },
             {
+                "code": "reportUnknownVariableType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportUnknownArgumentType",
                 "range": {
                     "startColumn": 43,

--- a/pudb/settings.py
+++ b/pudb/settings.py
@@ -168,7 +168,10 @@ def load_config():
 
     def normalize_bool_inplace(name: str):
         try:
-            if conf_dict[name].lower() in ["0", "false", "off"]:  # pyright: ignore[reportUnknownMemberType]
+            val = conf_dict[name]
+            if isinstance(val, bool):
+                return
+            if val.lower() in ["0", "false", "off"]:  # pyright: ignore[reportUnknownMemberType]
                 conf_dict[name] = False
             else:
                 conf_dict[name] = True


### PR DESCRIPTION
I was having issues when using pudb with Docker, the config file was not writable by the pudb process due to permissions errors, causing pudb to crash. This pr adds a check to fix that error. 